### PR TITLE
write log files when possible, add an option for odgi stats

### DIFF
--- a/pggb
+++ b/pggb
@@ -22,6 +22,7 @@ mapper=edyeet
 wf_min=100
 wf_diff=500
 merge_segments=false
+do_stats=false
 
 if [ $# -eq 0 ];
 then
@@ -29,7 +30,7 @@ then
 fi
 
 # read the options
-TEMP=`getopt -o i:p:a:n:s:K:k:w:j:P:e:t:vlhWD:L:M --long input-fasta:,map-pct-id:,align-pct-id:,n-secondary:,segment-length:,mash-kmer:,min-match-length:,max-block-weight:,max-path-jump:,min-subpath:,max-edge-jump:,threads:,viz,layout,help,wfmash,wf-dist:,wf-min:,merge-segments -n 'pggb' -- "$@"`
+TEMP=`getopt -o i:p:a:n:s:K:k:w:j:P:e:t:vlhWD:L:M:S --long input-fasta:,map-pct-id:,align-pct-id:,n-secondary:,segment-length:,mash-kmer:,min-match-length:,max-block-weight:,max-path-jump:,min-subpath:,max-edge-jump:,threads:,viz,layout,help,wfmash,wf-dist:,wf-min:,merge-segments:,stats -n 'pggb' -- "$@"`
 eval set -- "$TEMP"
 
 # extract options and their arguments into variables.
@@ -53,6 +54,7 @@ while true ; do
         -t|--threads) threads=$2 ; shift 2 ;;
         -v|--do-viz) do_viz=true ; shift ;;
         -l|--do-layout) do_layout=true ; shift ;;
+        -S|--do-stats) do_stats=true ; shift ;;
         -h|--help) show_help=true ; shift ;;
         #-d|--debug) debug=true ; shift ;;
         --) shift ; break ;;
@@ -97,6 +99,7 @@ then
     echo "   [odgi]"
     echo "    -v, --viz                 render a visualization of the graph in 1D"
     echo "    -l, --layout              render a 2D layout of the graph"
+    echo "    -S, --stats               generate statistics of the seqwish and smoothxg graph [default: OFF]"
     echo "   [general]"
     echo "    -t, --threads N           number of compute threads to use in parallel steps"
     echo "    -h, --help                this text"
@@ -128,7 +131,7 @@ then
            -k $mash_kmer \
            -t $threads \
            $input_fasta $input_fasta \
-           >$f.paf
+           >$f.paf #2> >(tee $f.eydeet.log) This does not work, maybe related to https://stackoverflow.com/questions/11337041/force-line-buffering-of-stdout-when-piping-to-tee
 elif [[ "$mapper" == "wfmash" ]];
 then
     f=$f"-W-L"$wf_min"-D"$wf_diff
@@ -153,7 +156,8 @@ $timer -f "$fmt" seqwish \
        -p $f.paf \
        -k $min_match_length \
        -g $f.seqwish.gfa \
-       -P
+       -P \
+       2> >(tee $f.seqwish.log)
 
 $timer -f "$fmt" smoothxg \
        -t $threads \
@@ -164,31 +168,42 @@ $timer -f "$fmt" smoothxg \
        -e $max_edge_jump \
        -l $max_poa_length \
        -m $f.smooth.maf \
-       >$f.smooth.gfa
+       >$f.smooth.gfa 2> >(tee $f.smooth.log)
 
-$timer -f "$fmt" odgi build -g $f.smooth.gfa -o $f.smooth.og
+$timer -f "$fmt" odgi build -g $f.smooth.gfa -o $f.smooth.og 2> >(tee $f.smooth.build.log)
+
+if [[ $do_stats == true ]];
+then
+    $timer -f "$fmt" odgi build -g $f.seqwish.gfa -o $f.seqwish.og 2> >(tee $f.seqwish.build.log)
+    $timer -f "$fmt" odgi stats -i $f.seqwish.og -S -s -l -d >$f.seqwish.og.stats 2> >(tee $f.seqwish.og.stats.log)
+    $timer -f "$fmt" odgi stats -i $f.smooth.og -S -s -l -d >$f.smooth.og.stats 2> >(tee $f.smooth.og.stats.log)
+fi
 
 if [[ $do_viz == true ]];
 then
     $timer -f "$fmt" odgi viz -i $f.smooth.og \
                     -o $f.smooth.og.viz.png \
-                    -x 1500 -y 500 -P 5
+                    -x 1500 -y 500 -P 5 \
+                    2> >(tee $f.viz.log)
 fi
 
 if [[ $do_layout == true ]];
 then
     # the 2D layout is "smoother" when we chop the nodes of the graph to a fixed maximum length
-    $timer -f "$fmt" odgi chop -i $f.smooth.og -c 100 -o $f.smooth.chop.og
+    $timer -f "$fmt" odgi chop -i $f.smooth.og -c 100 -o $f.smooth.chop.og \
+    2> >(tee $f.chop.log)
 
     # adding -N to this call can help when rendering large, complex graphs that aren't globally linear
     $timer -f "$fmt" odgi layout -i $f.smooth.chop.og \
                        -o $f.smooth.chop.og.lay \
-                       -t $threads -P
+                       -t $threads -P \
+                       2> >(tee $f.layout.log)
 
     # this can be configured to draw the graph in different ways, based on the same layout
     $timer -f "$fmt" odgi draw -i $f.smooth.chop.og \
                      -c $f.smooth.chop.og.lay \
                      -p $f.smooth.chop.og.lay.png \
                      -C -w 20 \
-                     -H 1500 -t $threads
+                     -H 1500 -t $threads \
+                     2> >(tee $f.draw.log)
 fi

--- a/pggb
+++ b/pggb
@@ -131,7 +131,7 @@ then
            -k $mash_kmer \
            -t $threads \
            $input_fasta $input_fasta \
-           >$f.paf #2> >(tee $f.eydeet.log) This does not work, maybe related to https://stackoverflow.com/questions/11337041/force-line-buffering-of-stdout-when-piping-to-tee
+           >$f.paf 2> $f.edyeet.log #2> >(tee $f.eydeet.log) This does not work, maybe related to https://stackoverflow.com/questions/11337041/force-line-buffering-of-stdout-when-piping-to-tee
 elif [[ "$mapper" == "wfmash" ]];
 then
     f=$f"-W-L"$wf_min"-D"$wf_diff
@@ -146,7 +146,7 @@ then
            -d $wf_diff \
            -t $threads \
            $input_fasta $input_fasta \
-           >$f.paf
+           >$f.paf 2> $f.wfmash.log
 fi
 
 


### PR DESCRIPTION
We now log everything that is printed to stdout into a file for each process. However, `tee` is unhappy with `edyeet` and `wfmash`. For these tools I was not able to both print to console and a file at the same time, so I left it as it is.
Also, there is a possibility to run `odgi stats` for the `seqwish` and `smoothxg` GFAs. Just use `-S|--stats`.