### PR TITLE
optionally apply pigz to compressible products

### DIFF
--- a/.github/workflows/build_and_test_docker.yml
+++ b/.github/workflows/build_and_test_docker.yml
@@ -10,10 +10,10 @@ jobs:
       - name: Build the Docker image
         run: docker build . --file Dockerfile --target binary --tag pggb
       - name: Run a test on the DRB1-3123 dataset (wfmash)
-        run: docker run -v ${PWD}/data/:/data pggb "pggb -i data/HLA/DRB1-3123.fa.gz -s 3000 -p 70 -a 70 -n 10 -t 2 -v -L -m -W"
+        run: docker run -v ${PWD}/data/:/data pggb "pggb -i data/HLA/DRB1-3123.fa.gz -s 3000 -p 70 -a 70 -n 10 -t 2 -v -L -m -W -Z"
       - name: Run a test on the LPA dataset (wfmash)
-        run: docker run -v ${PWD}/data/:/data pggb "pggb -i data/LPA/LPA.fa.gz -s 30000 -j 5000 -e 5000 -K 16 -k 19 -p 70 -a 70 -n 10 -t 2 -v -L -m -W"
+        run: docker run -v ${PWD}/data/:/data pggb "pggb -i data/LPA/LPA.fa.gz -s 30000 -j 5000 -e 5000 -K 16 -k 19 -p 70 -a 70 -n 10 -t 2 -v -L -m -W -Z"
       - name: Run a test on the DRB1-3123 dataset (edyeet)
-        run: docker run -v ${PWD}/data/:/data pggb "pggb -i data/HLA/DRB1-3123.fa.gz -s 3000 -p 70 -a 70 -n 10 -t 2 -v -L -m"
+        run: docker run -v ${PWD}/data/:/data pggb "pggb -i data/HLA/DRB1-3123.fa.gz -s 3000 -p 70 -a 70 -n 10 -t 2 -v -L -m -Z"
       - name: Run a test on the LPA dataset (edyeet)
-        run: docker run -v ${PWD}/data/:/data pggb "pggb -i data/LPA/LPA.fa.gz -s 30000 -j 5000 -e 5000 -K 16 -k 19 -p 70 -a 70 -n 10 -t 2 -v -L -m"
+        run: docker run -v ${PWD}/data/:/data pggb "pggb -i data/LPA/LPA.fa.gz -s 30000 -j 5000 -e 5000 -K 16 -k 19 -p 70 -a 70 -n 10 -t 2 -v -L -m -Z"

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN cd MultiQC \
     && git checkout adacbcb490baa5304443ea8532e7fc6964ecc358 \
     && pip install .
 
-RUN apt-get install -y time
+RUN apt-get install -y time pigz
 
 COPY pggb /usr/local/bin/pggb
 RUN chmod 777 /usr/local/bin/pggb

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get install -y \
                         zlib1g-dev
 RUN cd edyeet \
     && git pull \
-    && git checkout 776a0c8 \
+    && git checkout 03a28af \
     && sed -i 's/-march=native //g' CMakeLists.txt \
     && sed -i 's/-march=native //g' src/common/wflign/CMakeLists.txt \
     && cmake -H. -Bbuild && cmake --build build -- -j $(nproc) \
@@ -37,7 +37,7 @@ RUN cd ../
 RUN git clone --recursive https://github.com/ekg/wfmash
 RUN cd wfmash \
     && git pull \
-    && git checkout 4e3aaf0 \
+    && git checkout a25d52f \
     && sed -i 's/-march=native //g' CMakeLists.txt \
     && sed -i 's/-march=native //g' src/common/wflign/CMakeLists.txt \
     && cmake -H. -Bbuild && cmake --build build -- -j $(nproc) \
@@ -58,7 +58,7 @@ RUN git clone --recursive https://github.com/ekg/smoothxg
 RUN cd smoothxg \
     && git pull \
     && git submodule update \
-    && git checkout d1301d5 \
+    && git checkout 9102c47 \
     && sed -i 's/-march=native/-march=haswell/g' deps/abPOA/CMakeLists.txt \
     && cmake -H. -Bbuild && cmake --build build -- -j $(nproc) \
     && cp bin/smoothxg /usr/local/bin/smoothxg \

--- a/pggb
+++ b/pggb
@@ -35,6 +35,7 @@ exclude_delim=false
 consensus_spec=10,100,1000,10000
 no_splits=false
 multiqc=false
+pigz_compress=false
 
 if [ $# -eq 0 ];
 then
@@ -43,7 +44,7 @@ fi
 
 # read the options
 cmd=$0" "$@
-TEMP=`getopt -o i:o:p:a:n:s:l:K:k:B:w:j:P:e:t:vLhWMSY:G:C:I:R:Nr:m --long input-fasta:,output-dir:,map-pct-id:,align-pct-id:,n-secondary:,segment-length:,block-length-min:,mash-kmer:,min-match-length:,transclose-batch:,block-weight-max:,path-jump-max:,subpath-min:,edge-jump-max:,threads:,do-viz,do-layout,help,wfmash,no-merge-segments,do-stats,exclude-delim:,poa-length-max:,poa-params:,consensus-spec:,block-id-min:,ratio-contain:,no-splits,resume,multiqc -n 'pggb' -- "$@"`
+TEMP=`getopt -o i:o:p:a:n:s:l:K:k:B:w:j:P:e:t:vLhWMSY:G:C:I:R:NrmZ --long input-fasta:,output-dir:,map-pct-id:,align-pct-id:,n-secondary:,segment-length:,block-length-min:,mash-kmer:,min-match-length:,transclose-batch:,block-weight-max:,path-jump-max:,subpath-min:,edge-jump-max:,threads:,do-viz,do-layout,help,wfmash,no-merge-segments,do-stats,exclude-delim:,poa-length-max:,poa-params:,consensus-spec:,block-id-min:,ratio-contain:,no-splits,resume,multiqc,pigz-compress -n 'pggb' -- "$@"`
 eval set -- "$TEMP"
 
 # extract options and their arguments into variables.
@@ -77,6 +78,7 @@ while true ; do
         -S|--do-stats) do_stats=true ; shift ;;
         -m|--multiqc) multiqc=true ; shift ;;
         -r|--resume) resume=true ; shift ;;
+        -Z|--pigz) pigz_compress=true ; shift ;;
         -h|--help) show_help=true ; shift ;;
         #-d|--debug) debug=true ; shift ;;
         --) shift ; break ;;
@@ -153,6 +155,7 @@ then
     echo "    -r, --resume                do not overwrite existing output from edyeet, seqwish, smoothxg"
     echo "                                [default: start pipeline from scratch]"
     echo "    -t, --threads N             number of compute threads to use in parallel steps"
+    echo "    -Z, --pigz-compress         compress graph (.gfa) and MSA (.maf) outputs with pigz"
     echo "    -h, --help                  this text"
     echo
     echo "Use edyeet, seqwish, smoothxg, and odgi to build and display a pangenome graph."
@@ -400,4 +403,11 @@ then
         -o "$output_dir" \
         2> >(tee -a "$log_file")
     fi
+fi
+
+if [[ $pigz_compress == true ]];
+then
+    pigz -q -p $threads $prefix_paf*.paf
+    pigz -q -p $threads $prefix_seqwish*.{gfa,og}
+    pigz -q -p $threads $prefix_smoothed*.{og,maf}
 fi

--- a/pggb
+++ b/pggb
@@ -408,6 +408,5 @@ fi
 if [[ $pigz_compress == true ]];
 then
     pigz -q -p $threads $prefix_paf*.paf
-    pigz -q -p $threads $prefix_seqwish*.{gfa,og}
-    pigz -q -p $threads $prefix_smoothed*.{og,maf}
+    pigz -q -p $threads $prefix_seqwish*.{gfa,og,maf}
 fi


### PR DESCRIPTION
A frequent requirement is to compress the outputs, some of which (hello .maf) are highly compressible, redundant text collections. This enables the compression with the `-Z` flag.