### PR TITLE
Hybrid map

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN git clone --recursive https://github.com/ekg/smoothxg
 RUN cd smoothxg \
     && git pull \
     && git submodule update \
-    && git checkout ac005cf \
+    && git checkout 715bfea \
     && sed -i 's/-march=native/-march=haswell/g' deps/abPOA/CMakeLists.txt \
     && cmake -H. -Bbuild && cmake --build build -- -j $(nproc) \
     && cp bin/smoothxg /usr/local/bin/smoothxg \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ RUN git clone --recursive https://github.com/ekg/edyeet
 RUN apt-get install -y \
                         autoconf \
                         libgsl-dev \
-                        zlib1g-dev
+                        zlib1g-dev \
+                        libzstd-dev
 RUN cd edyeet \
     && git pull \
     && git checkout 03a28af \
@@ -37,7 +38,7 @@ RUN cd ../
 RUN git clone --recursive https://github.com/ekg/wfmash
 RUN cd wfmash \
     && git pull \
-    && git checkout d200025 \
+    && git checkout a932d64 \
     && sed -i 's/-mcx16 -march=native //g' CMakeLists.txt \
     && sed -i 's/-mcx16 -march=native //g' src/common/wflign/CMakeLists.txt \
     && cmake -H. -Bbuild && cmake --build build -- -j $(nproc) \
@@ -58,7 +59,7 @@ RUN git clone --recursive https://github.com/ekg/smoothxg
 RUN cd smoothxg \
     && git pull \
     && git submodule update \
-    && git checkout 22b793f \
+    && git checkout d20b3cb \
     && sed -i 's/-march=native/-march=haswell/g' deps/abPOA/CMakeLists.txt \
     && cmake -H. -Bbuild && cmake --build build -- -j $(nproc) \
     && cp bin/smoothxg /usr/local/bin/smoothxg \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN git clone --recursive https://github.com/ekg/edyeet \
 RUN git clone --recursive https://github.com/ekg/wfmash \
     && cd wfmash \
     && git pull \
-    && git checkout 71689e5 \
+    && git checkout 53ebad1 \
     && git submodule update --init --recursive \
     && sed -i 's/-mcx16 -march=native //g' CMakeLists.txt \
     && sed -i 's/-mcx16 -march=native //g' src/common/wflign/CMakeLists.txt \
@@ -60,7 +60,7 @@ RUN git clone --recursive https://github.com/ekg/seqwish \
 RUN git clone --recursive https://github.com/ekg/smoothxg \
     && cd smoothxg \
     && git pull \
-    && git checkout 439a83d \
+    && git checkout fb85d19 \
     && git submodule update --init --recursive \
     && sed -i 's/-march=native/-march=haswell/g' deps/abPOA/CMakeLists.txt \
     && cmake -H. -Bbuild && cmake --build build -- -j $(nproc) \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN cd ../
 RUN git clone --recursive https://github.com/ekg/wfmash
 RUN cd wfmash \
     && git pull \
-    && git checkout a25d52f \
+    && git checkout d200025 \
     && sed -i 's/-march=native //g' CMakeLists.txt \
     && sed -i 's/-march=native //g' src/common/wflign/CMakeLists.txt \
     && cmake -H. -Bbuild && cmake --build build -- -j $(nproc) \
@@ -58,7 +58,7 @@ RUN git clone --recursive https://github.com/ekg/smoothxg
 RUN cd smoothxg \
     && git pull \
     && git submodule update \
-    && git checkout 715bfea \
+    && git checkout 0c6bd70 \
     && sed -i 's/-march=native/-march=haswell/g' deps/abPOA/CMakeLists.txt \
     && cmake -H. -Bbuild && cmake --build build -- -j $(nproc) \
     && cp bin/smoothxg /usr/local/bin/smoothxg \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN git clone --recursive https://github.com/ekg/smoothxg
 RUN cd smoothxg \
     && git pull \
     && git submodule update \
-    && git checkout 9102c47 \
+    && git checkout 3a784ed \
     && sed -i 's/-march=native/-march=haswell/g' deps/abPOA/CMakeLists.txt \
     && cmake -H. -Bbuild && cmake --build build -- -j $(nproc) \
     && cp bin/smoothxg /usr/local/bin/smoothxg \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN git clone --recursive https://github.com/ekg/smoothxg
 RUN cd smoothxg \
     && git pull \
     && git submodule update \
-    && git checkout 3a784ed \
+    && git checkout 6fad48b \
     && sed -i 's/-march=native/-march=haswell/g' deps/abPOA/CMakeLists.txt \
     && cmake -H. -Bbuild && cmake --build build -- -j $(nproc) \
     && cp bin/smoothxg /usr/local/bin/smoothxg \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN git clone --recursive https://github.com/ekg/smoothxg
 RUN cd smoothxg \
     && git pull \
     && git submodule update \
-    && git checkout 6fad48b \
+    && git checkout ac005cf \
     && sed -i 's/-march=native/-march=haswell/g' deps/abPOA/CMakeLists.txt \
     && cmake -H. -Bbuild && cmake --build build -- -j $(nproc) \
     && cp bin/smoothxg /usr/local/bin/smoothxg \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN git clone --recursive https://github.com/ekg/edyeet \
 RUN git clone --recursive https://github.com/ekg/wfmash \
     && cd wfmash \
     && git pull \
-    && git checkout a932d64 \
+    && git checkout 3d1474d \
     && git submodule update --init --recursive \
     && sed -i 's/-mcx16 -march=native //g' CMakeLists.txt \
     && sed -i 's/-mcx16 -march=native //g' src/common/wflign/CMakeLists.txt \
@@ -51,7 +51,7 @@ RUN git clone --recursive https://github.com/ekg/wfmash \
 RUN git clone --recursive https://github.com/ekg/seqwish \
     && cd seqwish \
     && git pull \
-    && git checkout cbab96f \
+    && git checkout 3b8d6c2 \
     && git submodule update --init --recursive \
     && cmake -H. -Bbuild && cmake --build build -- -j $(nproc) \
     && cp bin/seqwish /usr/local/bin/seqwish \
@@ -60,7 +60,7 @@ RUN git clone --recursive https://github.com/ekg/seqwish \
 RUN git clone --recursive https://github.com/ekg/smoothxg \
     && cd smoothxg \
     && git pull \
-    && git checkout d20b3cb \
+    && git checkout 439a83d \
     && git submodule update --init --recursive \
     && sed -i 's/-march=native/-march=haswell/g' deps/abPOA/CMakeLists.txt \
     && cmake -H. -Bbuild && cmake --build build -- -j $(nproc) \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN git clone --recursive https://github.com/ekg/edyeet \
 RUN git clone --recursive https://github.com/ekg/wfmash \
     && cd wfmash \
     && git pull \
-    && git checkout 3d1474d \
+    && git checkout 71689e5 \
     && git submodule update --init --recursive \
     && sed -i 's/-mcx16 -march=native //g' CMakeLists.txt \
     && sed -i 's/-mcx16 -march=native //g' src/common/wflign/CMakeLists.txt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
                        autoconf \
                        libgsl-dev \
                        zlib1g-dev \
+                       libzstd-dev \
                        build-essential \
                        time \
                        pigz

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN git clone --recursive https://github.com/ekg/smoothxg
 RUN cd smoothxg \
     && git pull \
     && git submodule update \
-    && git checkout 0c6bd70 \
+    && git checkout 22b793f \
     && sed -i 's/-march=native/-march=haswell/g' deps/abPOA/CMakeLists.txt \
     && cmake -H. -Bbuild && cmake --build build -- -j $(nproc) \
     && cp bin/smoothxg /usr/local/bin/smoothxg \

--- a/pggb
+++ b/pggb
@@ -38,7 +38,6 @@ no_splits=false
 multiqc=false
 pigz_compress=false
 hyb_pct_id=false
-uniq_output_dir=false
 
 if [ $# -eq 0 ];
 then
@@ -47,7 +46,7 @@ fi
 
 # read the options
 cmd=$0" "$@
-TEMP=`getopt -o i:o:p:a:n:s:l:K:k:B:w:j:P:e:t:vLhEH:MSY:G:C:Q:I:R:Nr:mZu --long input-fasta:,output-dir:,map-pct-id:,align-pct-id:,n-secondary:,segment-length:,block-length-min:,mash-kmer:,min-match-length:,transclose-batch:,block-weight-max:,path-jump-max:,subpath-min:,edge-jump-max:,threads:,do-viz,do-layout,help,edyeet,hyb-pct-id:,no-merge-segments,do-stats,exclude-delim:,poa-length-max:,poa-params:,consensus-spec:,consensus-prefix:,block-id-min:,block-ratio-min:,no-splits,resume:,multiqc,pigz-compress,uniq-output-dir -n 'pggb' -- "$@"`
+TEMP=`getopt -o i:o:p:a:n:s:l:K:k:B:w:j:P:e:t:vLhEH:MSY:G:C:Q:I:R:NrmZ --long input-fasta:,output-dir:,map-pct-id:,align-pct-id:,n-secondary:,segment-length:,block-length-min:,mash-kmer:,min-match-length:,transclose-batch:,block-weight-max:,path-jump-max:,subpath-min:,edge-jump-max:,threads:,do-viz,do-layout,help,edyeet,hyb-pct-id:,no-merge-segments,do-stats,exclude-delim:,poa-length-max:,poa-params:,consensus-spec:,consensus-prefix:,block-id-min:,block-ratio-min:,no-splits,resume,multiqc,pigz-compress -n 'pggb' -- "$@"`
 eval set -- "$TEMP"
 
 # extract options and their arguments into variables.
@@ -82,9 +81,8 @@ while true ; do
         -L|--do-layout) do_layout=true ; shift ;;
         -S|--do-stats) do_stats=true ; shift ;;
         -m|--multiqc) multiqc=true ; shift ;;
-        -r|--resume) resume=$2 ; shift 2 ;;
+        -r|--resume) resume=true ; shift ;;
         -Z|--pigz) pigz_compress=true ; shift ;;
-        -u|--uniq-output-dir) uniq_output_dir=true ; shift ;;
         -h|--help) show_help=true ; shift ;;
         #-d|--debug) debug=true ; shift ;;
         --) shift ; break ;;
@@ -165,7 +163,6 @@ then
     echo "                                [default: start pipeline from scratch in a new directory]"
     echo "    -t, --threads N             number of compute threads to use in parallel steps"
     echo "    -Z, --pigz-compress         compress alignment (.paf), graph (.gfa, .og), and MSA (.maf) outputs with pigz"
-    echo "    -u, --uniq-output-dir       extend the -o/--output-dir PATH with all parameters and a unique timestamp"
     echo "    -h, --help                  this text"
     echo
     echo "Use wfmash, seqwish, smoothxg, and odgi to build and display a pangenome graph."
@@ -227,20 +224,6 @@ prefix_smoothed="$prefix_seqwish".smooth-w$max_block_weight-j$max_path_jump-e$ma
 fmt="%C\n%Us user %Ss system %P cpu %es total %MKb max memory"
 timer=/usr/bin/time
 
-date=`date "+%m-%d-%Y_%H:%M:%S"`
-
-if [[ "$uniq_output_dir" != false ]]; then
-    if [[ "$output_dir" != "" ]]; then
-        output_dir="$output_dir"_$(basename "$prefix_smoothed")_"$date"
-    else 
-        output_dir=$(basename "$prefix_smoothed")_"$date"
-    fi
-fi
-
-if [[ "$resume" != false ]]; then
-    output_dir="$resume"
-fi
-
 if [[ "$output_dir" != "" ]]; then
 	if [ ! -e "$output_dir" ]; then
 		mkdir "$output_dir"
@@ -250,6 +233,7 @@ if [[ "$output_dir" != "" ]]; then
 	prefix_smoothed="$output_dir"/$(basename "$prefix_smoothed")
 fi
 
+date=`date "+%m-%d-%Y_%H:%M:%S"`
 log_file="$prefix_smoothed".$date.log
 param_file="$prefix_smoothed".$date.params.yml
 
@@ -267,7 +251,6 @@ general:
   output-dir:         $output_dir
   resume:             $resume
   pigz-compress:      $pigz_compress
-  uniq-output-dir:    $uniq_output_dir
   threads:            $threads
 alignment:
   mapping-tool:       $mapper

--- a/pggb
+++ b/pggb
@@ -363,8 +363,6 @@ if [[ ! -s $prefix_smoothed.gfa || $resume == false ]]; then
         -t $threads \
         -g "$prefix_seqwish".gfa \
         -w $max_block_weight \
-        -M \
-        -J 0.7 \
         -K \
         -G 150 \
         -I $block_id_min \

--- a/pggb
+++ b/pggb
@@ -33,6 +33,7 @@ no_merge_segments=false
 do_stats=false
 exclude_delim=false
 consensus_spec=10,100,1000,10000
+consensus_prefix=Consensus_
 no_splits=false
 multiqc=false
 pigz_compress=false
@@ -45,7 +46,7 @@ fi
 
 # read the options
 cmd=$0" "$@
-TEMP=`getopt -o i:o:p:a:n:s:l:K:k:B:w:j:P:e:t:vLhWH:MSY:G:C:I:R:NrmZ --long input-fasta:,output-dir:,map-pct-id:,align-pct-id:,n-secondary:,segment-length:,block-length-min:,mash-kmer:,min-match-length:,transclose-batch:,block-weight-max:,path-jump-max:,subpath-min:,edge-jump-max:,threads:,do-viz,do-layout,help,wfmash,hyb-pct-id:,no-merge-segments,do-stats,exclude-delim:,poa-length-max:,poa-params:,consensus-spec:,block-id-min:,ratio-contain:,no-splits,resume,multiqc,pigz-compress -n 'pggb' -- "$@"`
+TEMP=`getopt -o i:o:p:a:n:s:l:K:k:B:w:j:P:e:t:vLhWH:MSY:G:C:Q:I:R:NrmZ --long input-fasta:,output-dir:,map-pct-id:,align-pct-id:,n-secondary:,segment-length:,block-length-min:,mash-kmer:,min-match-length:,transclose-batch:,block-weight-max:,path-jump-max:,subpath-min:,edge-jump-max:,threads:,do-viz,do-layout,help,wfmash,hyb-pct-id:,no-merge-segments,do-stats,exclude-delim:,poa-length-max:,poa-params:,consensus-spec:,consensus-prefix:,block-id-min:,ratio-contain:,no-splits,resume,multiqc,pigz-compress -n 'pggb' -- "$@"`
 eval set -- "$TEMP"
 
 # extract options and their arguments into variables.
@@ -74,6 +75,7 @@ while true ; do
         -G|--poa-length-max) max_poa_length=$2 ; shift 2 ;;
         -P|--poa-params) poa_params=$2 ; shift 2 ;;
         -C|--consensus-spec) consensus_spec=$2 ; shift 2 ;;
+        -Q|--consensus-prefix) consensus_prefix=$2 ; shift 2 ;;
         -t|--threads) threads=$2 ; shift 2 ;;
         -v|--do-viz) do_viz=true ; shift ;;
         -L|--do-layout) do_layout=true ; shift ;;
@@ -139,6 +141,7 @@ then
     echo "    -G, --poa-length-max N      maximum sequence length to put into POA [default: 10000]"
     echo "    -P, --poa-params PARAMS     score parameters for POA in the form of match,mismatch,gap1,ext1,gap2,ext2"
     echo "                                [default: 1,4,6,2,26,1]"
+    echo "    -Q, --consensus-prefix P    use this prefix for consensus path names [default: Consensus_]"
     echo "    -C, --consensus-spec SPEC   consensus graph specification: write the consensus graph to"
     echo "                                BASENAME.cons_[spec].gfa; where each spec contains at least a min_len parameter"
     echo "                                (which defines the length of divergences from consensus paths to preserve in the"
@@ -271,6 +274,7 @@ smoothxg:
   edge-jump-max:      $max_edge_jump
   poa-length-max:     $max_poa_length
   poa-params:         $poa_params
+  consensus-prefix:   $consensus_prefix
   consensus-spec:     $consensus_spec
   block-id-min:       $block_id_min
   ratio-contain:      $ratio_contain
@@ -372,6 +376,7 @@ if [[ ! -s $prefix_smoothed.gfa || $resume == false ]]; then
         -p "$poa_params" \
         -m "$prefix_smoothed".maf \
         -C "$prefix_smoothed".consensus,$consensus_spec \
+        -Q $consensus_prefix \
         -o "$prefix_smoothed".gfa \
         2> >(tee -a "$log_file")
 fi

--- a/pggb
+++ b/pggb
@@ -15,8 +15,7 @@ mash_kmer=16
 min_match_length=19
 transclose_batch=1000000
 max_block_weight=10000
-block_id_min=0
-ratio_contain=0
+block_id_min=0.5
 max_path_jump=5000
 max_edge_jump=5000
 max_poa_length=10000
@@ -46,7 +45,7 @@ fi
 
 # read the options
 cmd=$0" "$@
-TEMP=`getopt -o i:o:p:a:n:s:l:K:k:B:w:j:P:e:t:vLhWH:MSY:G:C:Q:I:R:NrmZ --long input-fasta:,output-dir:,map-pct-id:,align-pct-id:,n-secondary:,segment-length:,block-length-min:,mash-kmer:,min-match-length:,transclose-batch:,block-weight-max:,path-jump-max:,subpath-min:,edge-jump-max:,threads:,do-viz,do-layout,help,wfmash,hyb-pct-id:,no-merge-segments,do-stats,exclude-delim:,poa-length-max:,poa-params:,consensus-spec:,consensus-prefix:,block-id-min:,ratio-contain:,no-splits,resume,multiqc,pigz-compress -n 'pggb' -- "$@"`
+TEMP=`getopt -o i:o:p:a:n:s:l:K:k:B:w:j:P:e:t:vLhWH:MSY:G:C:Q:I:NrmZ --long input-fasta:,output-dir:,map-pct-id:,align-pct-id:,n-secondary:,segment-length:,block-length-min:,mash-kmer:,min-match-length:,transclose-batch:,block-weight-max:,path-jump-max:,subpath-min:,edge-jump-max:,threads:,do-viz,do-layout,help,wfmash,hyb-pct-id:,no-merge-segments,do-stats,exclude-delim:,poa-length-max:,poa-params:,consensus-spec:,consensus-prefix:,block-id-min:,no-splits,resume,multiqc,pigz-compress -n 'pggb' -- "$@"`
 eval set -- "$TEMP"
 
 # extract options and their arguments into variables.
@@ -69,7 +68,6 @@ while true ; do
         -B|--transclose-batch) transclose_batch=$2 ; shift 2 ;;
         -w|--block-weight-max) max_block_weight=$2 ; shift 2 ;;
         -I|--block-id-min) block_id_min=$2 ; shift 2 ;;
-        -R|--ratio-contain) ratio_contain=$2 ; shift 2 ;;
         -j|--path-jump-max) max_path_jump=$2 ; shift 2 ;;
         -e|--edge-jump-max) max_edge_jump=$2 ; shift 2 ;;
         -G|--poa-length-max) max_poa_length=$2 ; shift 2 ;;
@@ -133,9 +131,7 @@ then
     echo "    -B, --transclose-batch      number of bp to use for transitive closure batch [default: 1000000]"
     echo "   [smoothxg]"
     echo "    -w, --block-weight-max N    maximum seed sequence in block [default: 10000]"
-    echo "    -I, --block-id-min N        split blocks into groups connected by this identity threshold [default: 0 / OFF]"
-    echo "    -R, --ratio-contain N       minimum short length / long length ratio to compare sequences for the containment"
-    echo "                                metric in the clustering [default: 0, no containment metric]"
+    echo "    -I, --block-id-min N        split blocks into groups connected by this identity threshold [default: 0.5]"
     echo "    -j, --path-jump-max         maximum path jump to include in block [default: 5000]"
     echo "    -e, --edge-jump-max N       maximum edge jump before breaking [default: 5000]"
     echo "    -G, --poa-length-max N      maximum sequence length to put into POA [default: 10000]"
@@ -219,7 +215,7 @@ prefix_seqwish="$prefix_paf".seqwish-k$min_match_length-B$transclose_batch
 poa_params_display=$(echo "$poa_params" | tr "," "_")
 
 # Normalization
-prefix_smoothed="$prefix_seqwish".smooth-w$max_block_weight-j$max_path_jump-e$max_edge_jump-I$block_id_min-R$ratio_contain-p"$poa_params_display"
+prefix_smoothed="$prefix_seqwish".smooth-w$max_block_weight-j$max_path_jump-e$max_edge_jump-I$block_id_min-p"$poa_params_display"
 
 
 fmt="%C\n%Us user %Ss system %P cpu %es total %MKb max memory"
@@ -277,7 +273,6 @@ smoothxg:
   consensus-prefix:   $consensus_prefix
   consensus-spec:     $consensus_spec
   block-id-min:       $block_id_min
-  ratio-contain:      $ratio_contain
 odgi:
   viz:                $do_viz
   layout:             $do_layout
@@ -369,7 +364,6 @@ if [[ ! -s $prefix_smoothed.gfa || $resume == false ]]; then
         -K \
         -G 150 \
         -I $block_id_min \
-        -R $ratio_contain \
         -j $max_path_jump \
         -e $max_edge_jump \
         -l $max_poa_length \

--- a/pggb
+++ b/pggb
@@ -27,7 +27,7 @@ poa_params="1,4,6,2,26,1"
 do_viz=false
 do_layout=false
 threads=1
-mapper=edyeet
+mapper=wfmash
 no_merge_segments=false
 do_stats=false
 exclude_delim=false
@@ -45,7 +45,7 @@ fi
 
 # read the options
 cmd=$0" "$@
-TEMP=`getopt -o i:o:p:a:n:s:l:K:k:B:w:j:P:e:t:vLhWH:MSY:G:C:Q:I:NrmZ --long input-fasta:,output-dir:,map-pct-id:,align-pct-id:,n-secondary:,segment-length:,block-length-min:,mash-kmer:,min-match-length:,transclose-batch:,block-weight-max:,path-jump-max:,subpath-min:,edge-jump-max:,threads:,do-viz,do-layout,help,wfmash,hyb-pct-id:,no-merge-segments,do-stats,exclude-delim:,poa-length-max:,poa-params:,consensus-spec:,consensus-prefix:,block-id-min:,no-splits,resume,multiqc,pigz-compress -n 'pggb' -- "$@"`
+TEMP=`getopt -o i:o:p:a:n:s:l:K:k:B:w:j:P:e:t:vLhEH:MSY:G:C:Q:I:NrmZ --long input-fasta:,output-dir:,map-pct-id:,align-pct-id:,n-secondary:,segment-length:,block-length-min:,mash-kmer:,min-match-length:,transclose-batch:,block-weight-max:,path-jump-max:,subpath-min:,edge-jump-max:,threads:,do-viz,do-layout,help,edyeet,hyb-pct-id:,no-merge-segments,do-stats,exclude-delim:,poa-length-max:,poa-params:,consensus-spec:,consensus-prefix:,block-id-min:,no-splits,resume,multiqc,pigz-compress -n 'pggb' -- "$@"`
 eval set -- "$TEMP"
 
 # extract options and their arguments into variables.
@@ -61,7 +61,7 @@ while true ; do
         -M|--no-merge-segments) no_merge_segments=true ; shift ;;
         -N|--no-splits) no_splits=true ; shift ;;
         -K|--mash-kmer) mash_kmer=$2 ; shift 2 ;;
-        -W|--wfmash) mapper=wfmash ; shift ;;
+        -E|--edyeet) mapper=edyeet ; shift ;;
         -H|--hyb-pct-id) mapper=wfmash-hyb ; hyb_pct_id=$2 ; shift 2 ;;
         -Y|--exclude-delim) exclude_delim=$2 ; shift 2 ;;
         -k|--min-match-length) min_match_length=$2 ; shift 2 ;;
@@ -120,7 +120,7 @@ then
     echo "    -a, --align-pct-id PCT      percent identity in the edyeet edlib alignment step [default: 0]"
     echo "    -n, --n-secondary N         number of secondary mappings to retain in 'map' filter mode"
     echo "    -K, --mash-kmer N           kmer size for mashmap [default: 16]"
-    echo "    -W, --wfmash                use the wfmash edit-distance mashmapper [default: edyeet]"
+    echo "    -E, --edyeet                use the edyeet edit-distance mashmapper [default: wfmash]"
     echo "    -H, --hyb-pct-id PCT        use wfmash in two phases to increase alignment sensitivity"
     echo "                                  1) default, 2) unmerged (-M) with the specified PCT identity"
     echo "                                  and with segment-length = block-length [default: off]"
@@ -162,7 +162,7 @@ then
     echo "    -Z, --pigz-compress         compress graph (.gfa) and MSA (.maf) outputs with pigz"
     echo "    -h, --help                  this text"
     echo
-    echo "Use edyeet, seqwish, smoothxg, and odgi to build and display a pangenome graph."
+    echo "Use wfmash, seqwish, smoothxg, and odgi to build and display a pangenome graph."
     exit
 fi
 

--- a/pggb
+++ b/pggb
@@ -36,6 +36,7 @@ consensus_spec=10,100,1000,10000
 no_splits=false
 multiqc=false
 pigz_compress=false
+hyb_pct_id=false
 
 if [ $# -eq 0 ];
 then
@@ -44,7 +45,7 @@ fi
 
 # read the options
 cmd=$0" "$@
-TEMP=`getopt -o i:o:p:a:n:s:l:K:k:B:w:j:P:e:t:vLhWMSY:G:C:I:R:NrmZ --long input-fasta:,output-dir:,map-pct-id:,align-pct-id:,n-secondary:,segment-length:,block-length-min:,mash-kmer:,min-match-length:,transclose-batch:,block-weight-max:,path-jump-max:,subpath-min:,edge-jump-max:,threads:,do-viz,do-layout,help,wfmash,no-merge-segments,do-stats,exclude-delim:,poa-length-max:,poa-params:,consensus-spec:,block-id-min:,ratio-contain:,no-splits,resume,multiqc,pigz-compress -n 'pggb' -- "$@"`
+TEMP=`getopt -o i:o:p:a:n:s:l:K:k:B:w:j:P:e:t:vLhWH:MSY:G:C:I:R:NrmZ --long input-fasta:,output-dir:,map-pct-id:,align-pct-id:,n-secondary:,segment-length:,block-length-min:,mash-kmer:,min-match-length:,transclose-batch:,block-weight-max:,path-jump-max:,subpath-min:,edge-jump-max:,threads:,do-viz,do-layout,help,wfmash,hyb-pct-id:,no-merge-segments,do-stats,exclude-delim:,poa-length-max:,poa-params:,consensus-spec:,block-id-min:,ratio-contain:,no-splits,resume,multiqc,pigz-compress -n 'pggb' -- "$@"`
 eval set -- "$TEMP"
 
 # extract options and their arguments into variables.
@@ -61,6 +62,7 @@ while true ; do
         -N|--no-splits) no_splits=true ; shift ;;
         -K|--mash-kmer) mash_kmer=$2 ; shift 2 ;;
         -W|--wfmash) mapper=wfmash ; shift ;;
+        -H|--hyb-pct-id) mapper=wfmash-hyb ; hyb_pct_id=$2 ; shift 2 ;;
         -Y|--exclude-delim) exclude_delim=$2 ; shift 2 ;;
         -k|--min-match-length) min_match_length=$2 ; shift 2 ;;
         -B|--transclose-batch) transclose_batch=$2 ; shift 2 ;;
@@ -119,6 +121,9 @@ then
     echo "    -n, --n-secondary N         number of secondary mappings to retain in 'map' filter mode"
     echo "    -K, --mash-kmer N           kmer size for mashmap [default: 16]"
     echo "    -W, --wfmash                use the wfmash edit-distance mashmapper [default: edyeet]"
+    echo "    -H, --hyb-pct-id PCT        use wfmash in two phases to increase alignment sensitivity"
+    echo "                                  1) default, 2) unmerged (-M) with the specified PCT identity"
+    echo "                                  and with segment-length = block-length [default: off]"
     echo "    -Y, --exclude-delim C       skip mappings between sequences with the same name prefix before"
     echo "                                the given delimiter character [default: all-vs-all and !self]"
     echo "   [seqwish]"
@@ -168,6 +173,10 @@ if [[ "$mapper" == "wfmash" ]];
 then
   mapper_letter='W'
 fi
+if [[ "$mapper" == "wfmash-hyb" ]];
+then
+  mapper_letter='H'$hyb_pct_id
+fi
 
 prefix_paf="$input_fasta".pggb-$mapper_letter-s$segment_length-l$block_length-p$map_pct_id-n$n_secondary-a$align_pct_id-K$mash_kmer
 
@@ -196,6 +205,9 @@ then
 elif [[ $mapper == "wfmash" ]];
 then
     prefix_paf="$prefix_paf"
+elif [[ $mapper == "wfmash-hyb" ]];
+then
+    prefix_paf="$prefix_paf"
 fi
 
 # Graph induction
@@ -204,7 +216,7 @@ prefix_seqwish="$prefix_paf".seqwish-k$min_match_length-B$transclose_batch
 poa_params_display=$(echo "$poa_params" | tr "," "_")
 
 # Normalization
-prefix_smoothed="$prefix_seqwish".smooth-w$max_block_weight-j$max_path_jump-e$max_edge_jump-I$block_id_min-p"$poa_params_display"
+prefix_smoothed="$prefix_seqwish".smooth-w$max_block_weight-j$max_path_jump-e$max_edge_jump-I$block_id_min-R$ratio_contain-p"$poa_params_display"
 
 
 fmt="%C\n%Us user %Ss system %P cpu %es total %MKb max memory"
@@ -248,6 +260,7 @@ alignment:
   n-secondary:        $n_secondary
   mash-kmer:          $mash_kmer
   wfmash:             $wfmash_bool
+  hyb-pct-id:         $hyb_pct_id
   exclude-delim:      $exclude_delim
 seqwish:
   min-match-len:      $min_match_length
@@ -300,6 +313,33 @@ if [[ ! -s "$prefix_paf".paf || $resume == false ]]; then
               -t $threads \
               "$input_fasta" "$input_fasta" \
               > "$prefix_paf".paf) 2> >(tee -a "$log_file")
+  elif [[ "$mapper" == "wfmash-hyb" ]];
+  then
+          ($timer -f "$fmt" wfmash \
+              $exclude_cmd \
+              -s $segment_length \
+              -l $block_length \
+              $merge_cmd \
+              $split_cmd \
+              -p $map_pct_id \
+              -n $n_secondary \
+              -k $mash_kmer \
+              -t $threads \
+              "$input_fasta" "$input_fasta" \
+              > "$prefix_paf".paf) 2> >(tee -a "$log_file")
+          ($timer -f "$fmt" wfmash \
+              $exclude_cmd \
+              -s $block_length \
+              -l 0 -M \
+              $split_cmd \
+              -p $hyb_pct_id \
+              -n $n_secondary \
+              -k $mash_kmer \
+              -t $threads \
+              "$input_fasta" "$input_fasta" \
+              > "$prefix_paf".hyb.paf) 2> >(tee -a "$log_file")
+          cat "$prefix_paf".hyb.paf >>"$prefix_paf".paf
+          rm -f "$prefix_paf".hyb.paf
   fi
 fi
 

--- a/pggb
+++ b/pggb
@@ -16,6 +16,7 @@ min_match_length=19
 transclose_batch=1000000
 max_block_weight=10000
 block_id_min=0.5
+
 max_path_jump=5000
 max_edge_jump=5000
 max_poa_length=10000
@@ -23,7 +24,7 @@ max_poa_length=10000
 # - asm5, --poa-params 1,19,39,3,81,1, ~0.1 divergence
 # - asm10, --poa-params 1,9,16,2,41,1, ~1 divergence
 # - asm20, --poa-params 1,4,6,2,26,1, ~5% divergence
-poa_params="1,4,6,2,26,1"
+poa_params="1,7,11,2,33,1"
 do_viz=false
 do_layout=false
 threads=1
@@ -136,7 +137,7 @@ then
     echo "    -e, --edge-jump-max N       maximum edge jump before breaking [default: 5000]"
     echo "    -G, --poa-length-max N      maximum sequence length to put into POA [default: 10000]"
     echo "    -P, --poa-params PARAMS     score parameters for POA in the form of match,mismatch,gap1,ext1,gap2,ext2"
-    echo "                                [default: 1,4,6,2,26,1]"
+    echo "                                [default: 1,7,11,2,33,1]"
     echo "    -Q, --consensus-prefix P    use this prefix for consensus path names [default: Consensus_]"
     echo "    -C, --consensus-spec SPEC   consensus graph specification: write the consensus graph to"
     echo "                                BASENAME.cons_[spec].gfa; where each spec contains at least a min_len parameter"

--- a/pggb
+++ b/pggb
@@ -16,7 +16,7 @@ min_match_length=19
 transclose_batch=1000000
 max_block_weight=10000
 block_id_min=0.5
-
+block_ratio_min=0.05
 max_path_jump=5000
 max_edge_jump=5000
 max_poa_length=10000
@@ -46,7 +46,7 @@ fi
 
 # read the options
 cmd=$0" "$@
-TEMP=`getopt -o i:o:p:a:n:s:l:K:k:B:w:j:P:e:t:vLhEH:MSY:G:C:Q:I:NrmZ --long input-fasta:,output-dir:,map-pct-id:,align-pct-id:,n-secondary:,segment-length:,block-length-min:,mash-kmer:,min-match-length:,transclose-batch:,block-weight-max:,path-jump-max:,subpath-min:,edge-jump-max:,threads:,do-viz,do-layout,help,edyeet,hyb-pct-id:,no-merge-segments,do-stats,exclude-delim:,poa-length-max:,poa-params:,consensus-spec:,consensus-prefix:,block-id-min:,no-splits,resume,multiqc,pigz-compress -n 'pggb' -- "$@"`
+TEMP=`getopt -o i:o:p:a:n:s:l:K:k:B:w:j:P:e:t:vLhEH:MSY:G:C:Q:I:R:NrmZ --long input-fasta:,output-dir:,map-pct-id:,align-pct-id:,n-secondary:,segment-length:,block-length-min:,mash-kmer:,min-match-length:,transclose-batch:,block-weight-max:,path-jump-max:,subpath-min:,edge-jump-max:,threads:,do-viz,do-layout,help,edyeet,hyb-pct-id:,no-merge-segments,do-stats,exclude-delim:,poa-length-max:,poa-params:,consensus-spec:,consensus-prefix:,block-id-min:,block-ratio-min:,no-splits,resume,multiqc,pigz-compress -n 'pggb' -- "$@"`
 eval set -- "$TEMP"
 
 # extract options and their arguments into variables.
@@ -69,6 +69,7 @@ while true ; do
         -B|--transclose-batch) transclose_batch=$2 ; shift 2 ;;
         -w|--block-weight-max) max_block_weight=$2 ; shift 2 ;;
         -I|--block-id-min) block_id_min=$2 ; shift 2 ;;
+        -R|--block-ratio-min) block_ratio_min=$2 ; shift 2 ;;
         -j|--path-jump-max) max_path_jump=$2 ; shift 2 ;;
         -e|--edge-jump-max) max_edge_jump=$2 ; shift 2 ;;
         -G|--poa-length-max) max_poa_length=$2 ; shift 2 ;;
@@ -133,6 +134,7 @@ then
     echo "   [smoothxg]"
     echo "    -w, --block-weight-max N    maximum seed sequence in block [default: 10000]"
     echo "    -I, --block-id-min N        split blocks into groups connected by this identity threshold [default: 0.5]"
+    echo "    -R, --block-ratio-min N     minimum small / large length ratio to cluster in a block [default: 0.05]"
     echo "    -j, --path-jump-max         maximum path jump to include in block [default: 5000]"
     echo "    -e, --edge-jump-max N       maximum edge jump before breaking [default: 5000]"
     echo "    -G, --poa-length-max N      maximum sequence length to put into POA [default: 10000]"
@@ -216,7 +218,7 @@ prefix_seqwish="$prefix_paf".seqwish-k$min_match_length-B$transclose_batch
 poa_params_display=$(echo "$poa_params" | tr "," "_")
 
 # Normalization
-prefix_smoothed="$prefix_seqwish".smooth-w$max_block_weight-j$max_path_jump-e$max_edge_jump-I$block_id_min-p"$poa_params_display"
+prefix_smoothed="$prefix_seqwish".smooth-w$max_block_weight-j$max_path_jump-e$max_edge_jump-I$block_id_min-R$block_ratio_min-p"$poa_params_display"
 
 
 fmt="%C\n%Us user %Ss system %P cpu %es total %MKb max memory"
@@ -274,6 +276,7 @@ smoothxg:
   consensus-prefix:   $consensus_prefix
   consensus-spec:     $consensus_spec
   block-id-min:       $block_id_min
+  block-ratio-min:    $block_ratio_min
 odgi:
   viz:                $do_viz
   layout:             $do_layout
@@ -365,6 +368,7 @@ if [[ ! -s $prefix_smoothed.gfa || $resume == false ]]; then
         -K \
         -G 150 \
         -I $block_id_min \
+        -R $block_ratio_min \
         -j $max_path_jump \
         -e $max_edge_jump \
         -l $max_poa_length \

--- a/pggb
+++ b/pggb
@@ -365,7 +365,7 @@ if [[ ! -s $prefix_smoothed.gfa || $resume == false ]]; then
         -w $max_block_weight \
         -K \
         -M \
-        -J 1
+        -J 1 \
         -G 150 \
         -I $block_id_min \
         -R $block_ratio_min \

--- a/pggb
+++ b/pggb
@@ -364,6 +364,8 @@ if [[ ! -s $prefix_smoothed.gfa || $resume == false ]]; then
         -g "$prefix_seqwish".gfa \
         -w $max_block_weight \
         -K \
+        -M \
+        -J 1
         -G 150 \
         -I $block_id_min \
         -R $block_ratio_min \


### PR DESCRIPTION
This sets up a new hybrid mapping mode where we:

1. map with default wfmash
2. map with wfmash -M (no-merge) and use the pggb "block-length" `-l` as the segment length `-s` input to wfmash (and set `-l` to 0)

The results are combined without filtering.

The logic is that the first phase encourages the alignment graph to form a star topology rooted in the longest sequences. This is the effect of the plane-sweep query filtering algorithm in mashmap2.

The second phase uses an updated feature in wfmash, which is a filtering mode for non-merged alignments that keeps the best `-n` mappings per query chunk. This will add links to our alignment graph between the most-closely related sequences.