### PR TITLE
update wfmash with the fix in the CIGAR management in wflambda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
 RUN git clone --recursive https://github.com/ekg/wfmash \
     && cd wfmash \
     && git pull \
-    && git checkout 37b9e71 \
+    && git checkout d1f3cb6 \
     && git submodule update --init --recursive \
     && sed -i 's/-mcx16 //g' CMakeLists.txt \
     && sed -i 's/-march=native //g' CMakeLists.txt \


### PR DESCRIPTION
This updates `wfmash` to close the #107 issue.