### PR TITLE
smoothxg: replacing dset64-gccAtomic.hpp with dset64.hpp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN git clone --recursive https://github.com/ekg/seqwish \
 RUN git clone --recursive https://github.com/ekg/smoothxg \
     && cd smoothxg \
     && git pull \
-    && git checkout e0829ce \
+    && git checkout a635e20 \
     && git submodule update --init --recursive \
     && sed -i 's/-march=native/-march=haswell/g' deps/abPOA/CMakeLists.txt \
     && sed -i 's/-mcx16 //g' deps/WFA/CMakeLists.txt \


### PR DESCRIPTION
This updates `smoothxg`, hopefully solving https://github.com/pangenome/odgi/issues/282.