### PR TITLE
High div wfmash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
 RUN git clone --recursive https://github.com/ekg/wfmash \
     && cd wfmash \
     && git pull \
-    && git checkout 21f8c4b16048dbc34e3ed0041431513549fc6477 \
+    && git checkout 26ca3113ba9e6ef4ce50644ab51ea6d9f0255e04 \
     && git submodule update --init --recursive \
     && sed -i 's/-mcx16 //g' CMakeLists.txt \
     && sed -i 's/-march=native //g' CMakeLists.txt \
@@ -58,7 +58,7 @@ RUN git clone --recursive https://github.com/ekg/seqwish \
 RUN git clone --recursive https://github.com/ekg/smoothxg \
     && cd smoothxg \
     && git pull \
-    && git checkout 3cfb7b8205f68607d24a1bf561585716d1a37ba4 \
+    && git checkout 0f15c4ec6c88879092e0e85483eb6e893d889641 \
     && git submodule update --init --recursive \
     && sed -i 's/-march=native/-march=haswell/g' deps/abPOA/CMakeLists.txt \
     && sed -i 's/-mcx16 //g' deps/WFA/CMakeLists.txt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
 RUN git clone --recursive https://github.com/ekg/wfmash \
     && cd wfmash \
     && git pull \
-    && git checkout 948f1683d14927745aef781cdabeb66ac6c7880b \
+    && git checkout 21f8c4b16048dbc34e3ed0041431513549fc6477 \
     && git submodule update --init --recursive \
     && sed -i 's/-mcx16 //g' CMakeLists.txt \
     && sed -i 's/-march=native //g' CMakeLists.txt \
@@ -49,7 +49,7 @@ RUN git clone --recursive https://github.com/ekg/wfmash \
 RUN git clone --recursive https://github.com/ekg/seqwish \
     && cd seqwish \
     && git pull \
-    && git checkout 51ee55079ccb89402fdb50999268f3382678b083 \
+    && git checkout 88cd0ea5f086cadfaf21c4c363d71536a1a7ea09 \
     && git submodule update --init --recursive \
     && cmake -H. -Bbuild && cmake --build build -- -j $(nproc) \
     && cp bin/seqwish /usr/local/bin/seqwish \
@@ -58,7 +58,7 @@ RUN git clone --recursive https://github.com/ekg/seqwish \
 RUN git clone --recursive https://github.com/ekg/smoothxg \
     && cd smoothxg \
     && git pull \
-    && git checkout 0f383e5033c6af18d95f5d8dca0a6e17e5dbf524 \
+    && git checkout 0f15c4ec6c88879092e0e85483eb6e893d889641 \
     && git submodule update --init --recursive \
     && sed -i 's/-march=native/-march=haswell/g' deps/abPOA/CMakeLists.txt \
     && sed -i 's/-mcx16 //g' deps/WFA/CMakeLists.txt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
 RUN git clone --recursive https://github.com/ekg/wfmash \
     && cd wfmash \
     && git pull \
-    && git checkout 26ca3113ba9e6ef4ce50644ab51ea6d9f0255e04 \
+    && git checkout a36ab5fa3d435a3030fd584e653b016ca1e89313 \
     && git submodule update --init --recursive \
     && sed -i 's/-mcx16 //g' CMakeLists.txt \
     && sed -i 's/-march=native //g' CMakeLists.txt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN git clone --recursive https://github.com/ekg/seqwish \
 RUN git clone --recursive https://github.com/ekg/smoothxg \
     && cd smoothxg \
     && git pull \
-    && git checkout 0f15c4ec6c88879092e0e85483eb6e893d889641 \
+    && git checkout 3cfb7b8205f68607d24a1bf561585716d1a37ba4 \
     && git submodule update --init --recursive \
     && sed -i 's/-march=native/-march=haswell/g' deps/abPOA/CMakeLists.txt \
     && sed -i 's/-mcx16 //g' deps/WFA/CMakeLists.txt \

--- a/pggb
+++ b/pggb
@@ -109,9 +109,11 @@ then
     poa_threads=$threads
 fi
 
+block_length_cmd=""
 if [[ $block_length == false ]];
 then
     block_length=$(echo $segment_length '*' 3 | bc)
+    block_length_cmd="-l $block_length"
 fi
 
 if [[ $n_haps == false ]];
@@ -291,7 +293,7 @@ if [[ ! -s $prefix_paf.$mapper.paf || $resume == false ]]; then
           ($timer -f "$fmt" wfmash \
               $exclude_cmd \
               -s $segment_length \
-              -l $block_length \
+              $block_length_cmd \
               $merge_cmd \
               $split_cmd \
               -p $map_pct_id \

--- a/pggb
+++ b/pggb
@@ -6,9 +6,9 @@ set -eo pipefail
 input_fasta=false
 output_dir=""
 resume=false
-map_pct_id=false
+map_pct_id=95
 n_mappings=false
-segment_length=false
+segment_length=5000
 block_length=false
 mash_kmer=false
 min_match_length=47
@@ -90,13 +90,11 @@ done
 
 if [[
        "$input_fasta" == false
-    || $map_pct_id == false
     || $n_mappings == false
-    || $segment_length == false
    ]];
 then
     show_help=true
-    >&2 echo "Mandatory arguments -i, -s, -n, -p"
+    >&2 echo "Mandatory arguments -i, -n"
 fi
 
 if [[ $poa_threads == 0 ]];
@@ -150,15 +148,14 @@ fi
 if [ $show_help ];
 then
     padding=`printf %${#0}s` # prints as many spaces as the length of $0
-    echo "usage: $0 -i <input-fasta> -s <segment-length> -n <n-mappings>"
-    echo "       $padding -p <map-pct-id> [options]"
+    echo "usage: $0 -i <input-fasta> -n <n-mappings> [options]"
     echo "options:"
     echo "   [wfmash]"
     echo "    -i, --input-fasta FILE      input FASTA/FASTQ file"
-    echo "    -s, --segment-length N      segment length for mapping"
+    echo "    -s, --segment-length N      segment length for mapping [default: 5k]"
     echo "    -l, --block-length N        minimum block length filter for mapping [default: 3*segment-length]"
     echo "    -N, --no-split              disable splitting of input sequences during mapping [enabled by default]"
-    echo "    -p, --map-pct-id PCT        percent identity for mapping/alignment"
+    echo "    -p, --map-pct-id PCT        percent identity for mapping/alignment [default: 95]"
     echo "    -n, --n-mappings N          number of mappings to retain for each segment"
     echo "    -K, --mash-kmer N           kmer size for mapping [default: 16]"
     echo "    -Y, --exclude-delim C       skip mappings between sequences with the same name prefix before"

--- a/pggb
+++ b/pggb
@@ -120,11 +120,11 @@ fi
 poa_params_cmd=""
 if [[ $poa_params == false ]];
 then
-   if (( $map_pct_id >= 99.9 )); then
+   if (( $map_pct_id >= 98 )); then
        poa_params_cmd="-P 1,19,39,3,81,1,"
-   elif (( $map_pct_id >= 99 )); then
-       poa_params_cmd="-P 1,9,16,2,41,1"
    elif (( $map_pct_id >= 95 )); then
+       poa_params_cmd="-P 1,9,16,2,41,1"
+   elif (( $map_pct_id >= 90 )); then
        poa_params_cmd="-P 1,8,14,2,36,1"
    else
        poa_params_cmd="-P 1,7,11,2,33,1"

--- a/pggb
+++ b/pggb
@@ -127,11 +127,11 @@ fi
 poa_params_cmd=""
 if [[ $poa_params == false ]];
 then
-   if (( $map_pct_id >= 98 )); then
+   if (( $map_pct_id >= 95 )); then
        poa_params_cmd="-P 1,19,39,3,81,1,"
-   elif (( $map_pct_id >= 95 )); then
-       poa_params_cmd="-P 1,9,16,2,41,1"
    elif (( $map_pct_id >= 90 )); then
+       poa_params_cmd="-P 1,9,16,2,41,1"
+   elif (( $map_pct_id >= 80 )); then
        poa_params_cmd="-P 1,8,14,2,36,1"
    else
        poa_params_cmd="-P 1,7,11,2,33,1"

--- a/pggb
+++ b/pggb
@@ -127,17 +127,19 @@ fi
 poa_params_cmd=""
 if [[ $poa_params == false ]];
 then
-   if (( $map_pct_id >= 95 )); then
-       poa_params_cmd="-P 1,19,39,3,81,1,"
-   elif (( $map_pct_id >= 90 )); then
-       poa_params_cmd="-P 1,9,16,2,41,1"
-   elif (( $map_pct_id >= 80 )); then
-       poa_params_cmd="-P 1,8,14,2,36,1"
-   else
-       poa_params_cmd="-P 1,7,11,2,33,1"
-   fi
+    poa_params_cmd="-P 1,19,39,3,81,1"
 else
-    poa_params_cmd="-P $poa_params"
+    if [[ $poa_params == "asm5" ]]; then
+        poa_params_cmd="-P 1,19,39,3,81,1"
+    elif [[ $poa_params == "asm10" ]]; then
+        poa_params_cmd="-P 1,9,16,2,41,1"
+    elif [[ $poa_params == "asm15" ]]; then
+        poa_params_cmd="-P 1,7,11,2,33,1"
+    elif [[ $poa_params == "asm20" ]]; then
+        poa_params_cmd="-P 1,4,6,2,26,1"
+    else
+        poa_params_cmd="-P $poa_params"
+    fi
 fi
 
 if [[ $n_haps == false ]];
@@ -170,7 +172,8 @@ then
     echo "    -e, --edge-jump-max N       maximum edge jump before breaking [default: 0 / off]"
     echo "    -G, --poa-length-target N,M target sequence length for POA, first pass = N, second pass = M [default: 4001,4507]"
     echo "    -P, --poa-params PARAMS     score parameters for POA in the form of match,mismatch,gap1,ext1,gap2,ext2"
-    echo "                                [default: 1,19,39,3,81,1]"
+    echo "                                may also be given as presets: asm5, asm10, asm15, asm20"
+    echo "                                [default: 1,19,39,3,81,1 = asm5]"
     echo "    -O, --poa-padding N         pad each end of each sequence in POA with N*(longest_poa_seq) bp [default: 0.03]"
     echo "    -d, --pad-max-depth N       depth/haplotype at which we don't pad the POA problem [default: 100]"
     echo "    -M, --write-maf             write MAF output representing merged POA blocks [default: off]"

--- a/pggb
+++ b/pggb
@@ -19,12 +19,7 @@ pad_max_depth=100
 max_path_jump=0
 max_edge_jump=0
 target_poa_length=4001,4507
-# poa param suggestions from minimap2
-# - asm5, --poa-params 1,19,39,3,81,1, ~0.1 divergence
-# - asm10, --poa-params 1,9,16,2,41,1, ~1 divergence
-# - asm20, --poa-params 1,4,6,2,26,1, ~5% divergence
-# between asm10 and asm20 ~ 1,7,11,2,33,1
-poa_params="1,19,39,3,81,1"
+poa_params=false
 poa_padding=0.03
 do_viz=true
 do_layout=true
@@ -110,10 +105,32 @@ then
 fi
 
 block_length_cmd=""
-if [[ $block_length == false ]];
+if [[ $block_length != false ]];
 then
-    block_length=$(echo $segment_length '*' 3 | bc)
     block_length_cmd="-l $block_length"
+fi
+# n.b. by default wfmash auto-sets our block length based on its parameters
+
+# our partial order alignment parameters
+# poa param suggestions from minimap2
+# - asm5, --poa-params 1,19,39,3,81,1, ~0.1 divergence
+# - asm10, --poa-params 1,9,16,2,41,1, ~1 divergence
+# - asm20, --poa-params 1,4,6,2,26,1, ~5% divergence
+# between asm10 and asm20 ~ 1,7,11,2,33,1
+poa_params_cmd=""
+if [[ $poa_params == false ]];
+then
+   if (( $map_pct_id >= 99.9 )); then
+       poa_params_cmd="-P 1,19,39,3,81,1,"
+   elif (( $map_pct_id >= 99 )); then
+       poa_params_cmd="-P 1,9,16,2,41,1"
+   elif (( $map_pct_id >= 95 )); then
+       poa_params_cmd="-P 1,8,14,2,36,1"
+   else
+       poa_params_cmd="-P 1,7,11,2,33,1"
+   fi
+else
+    poa_params_cmd="-P $poa_params"
 fi
 
 if [[ $n_haps == false ]];
@@ -265,7 +282,7 @@ smoothxg:
   path-jump-max:      $max_path_jump
   edge-jump-max:      $max_edge_jump
   poa-length-target:  $target_poa_length
-  poa-params:         $poa_params
+  poa-params:         $poa_params_cmd
   write-maf:          $write_maf
   consensus-prefix:   $consensus_prefix
   consensus-spec:     $consensus_spec
@@ -357,7 +374,7 @@ do
                    -j $max_path_jump \
                    -e $max_edge_jump \
                    -l $poa_length \
-                   -p "$poa_params" \
+                   $poa_params_cmd \
                    -O $poa_padding \
                    -Y $(echo "$pad_max_depth * $n_haps" | bc) \
                    -d 0 -D 0 \
@@ -380,7 +397,7 @@ do
                    -j $max_path_jump \
                    -e $max_edge_jump \
                    -l $poa_length \
-                   -p "$poa_params" \
+                   $poa_params_cmd \
                    -O $poa_padding \
                    -Y $(echo "$pad_max_depth * $n_haps" | bc) \
                    -d 0 -D 0 \

--- a/pggb
+++ b/pggb
@@ -10,7 +10,7 @@ map_pct_id=false
 n_mappings=false
 segment_length=false
 block_length=false
-mash_kmer=16
+mash_kmer=false
 min_match_length=47
 transclose_batch=10000000
 n_haps=false
@@ -109,7 +109,14 @@ if [[ $block_length != false ]];
 then
     block_length_cmd="-l $block_length"
 fi
-# n.b. by default wfmash auto-sets our block length based on its parameters
+# wfmash auto-sets our block length based on its parameters
+
+mash_kmer_cmd=""
+if [[ $mash_kmer != false ]];
+then
+    mash_kmer_cmd="-k $mash_kmer"
+fi
+# wfmash auto-sets our kmer length based on its parameters
 
 # our partial order alignment parameters
 # poa param suggestions from minimap2
@@ -313,9 +320,9 @@ if [[ ! -s $prefix_paf.$mapper.paf || $resume == false ]]; then
               $block_length_cmd \
               $merge_cmd \
               $split_cmd \
+              $mash_kmer_cmd \
               -p $map_pct_id \
               -n $n_mappings \
-              -k $mash_kmer \
               -t $threads \
               "$input_fasta" "$input_fasta" \
               > "$prefix_paf".$mapper.paf) 2> >(tee -a "$log_file")


### PR DESCRIPTION
This integrates a new version of wfmash that works at higher divergence.

A feature of this updated version is that the default wfmash settings -p 95 -s 5k will tend to work for most contexts. These are now set as default, to simplify use. 95% tends to be a good threshold for "pangenome" applications from the same species. -s 5k is a decent length segment size that achieves a good balance between specificity and SV breakpoint sensitivity, even for large input data.