### PR TITLE
Handle `-n` differences between` pggb` and `wfmash`

### DIFF
--- a/.github/workflows/build_and_test_docker.yml
+++ b/.github/workflows/build_and_test_docker.yml
@@ -10,8 +10,8 @@ jobs:
       - name: Build the Docker image
         run: docker build . --file Dockerfile --target binary --tag pggb
       - name: Run a test on the DRB1-3123 dataset (wfmash)
-        run: docker run -v ${PWD}/data/:/data pggb "pggb -i data/HLA/DRB1-3123.fa.gz -p 70 -s 3000 -G 2000 -n 10 -t 2 -Z -V 'gi|568815561:#,gi|29124352:#' -o drib1 -M -m -C cons,10,100,1000,10000 && ls drib1/*"
+        run: docker run -v ${PWD}/data/:/data pggb "pggb -i data/HLA/DRB1-3123.fa.gz -p 70 -s 3000 -G 2000 -n 10 -t 2 -Z -V 'gi|568815561:#,gi|29124352:#' -o drib1 -M -m && ls drib1/*"
       - name: Run a test on the DRB1-3123 dataset (paf)
-        run: docker run -v ${PWD}/data/:/data pggb "pggb -i data/HLA/DRB1-3123.fa.gz -a data/paf/DRB1-3123.fa.15a1009.wfmash.paf -p 70 -s 3000 -G 2000 -n 10 -t 2 -Z -V 'gi|568815561:#,gi|29124352:#' -o drib2 -M -m -C cons,10,100,1000,10000 && ls drib2/*"  
+        run: docker run -v ${PWD}/data/:/data pggb "pggb -i data/HLA/DRB1-3123.fa.gz -a data/paf/DRB1-3123.fa.15a1009.wfmash.paf -p 70 -s 3000 -G 2000 -n 10 -t 2 -Z -V 'gi|568815561:#,gi|29124352:#' -o drib2 -M -m && ls drib2/*"
       - name: Run a test on the LPA dataset (wfmash)
-        run: docker run -v ${PWD}/data/:/data pggb "pggb -i data/LPA/LPA.fa.gz -p 95 -s 50000 -l 10000 -G 5000,5500 -n 90 -k 79 -t 2 -Z -C 10,100,1000,10000 -O 0.001 -m"
+        run: docker run -v ${PWD}/data/:/data pggb "pggb -i data/LPA/LPA.fa.gz -p 95 -s 50000 -l 10000 -G 5000,5500 -n 90 -k 79 -t 2 -Z -O 0.001 -m"

--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ Using a test from the `data/HLA` directory in this repo:
 ```sh
 git clone --recursive https://github.com/pangenome/pggb
 cd pggb
-./pggb -i data/HLA/DRB1-3123.fa.gz -p 70 -s 3000 -G 2000 -n 10 -t 16 -v -V 'gi|568815561:#' -o out -M -C cons,100,1000,10000
+./pggb -i data/HLA/DRB1-3123.fa.gz -p 70 -s 3000 -G 2000 -n 10 -t 16 -v -V 'gi|568815561:#' -o out -M
 ```
 
-This yields a variation graph in GFA format, a multiple sequence alignment in MAF format, a series of consensus graphs at different levels of variant resolution, and several diagnostic images (all in the directory `out/`).
+[comment]: <> (a series of consensus graphs at different levels of variant resolution)
+This yields a variation graph in GFA format, a multiple sequence alignment in MAF format, and several diagnostic images (all in the directory `out/`).
 By default, the outputs are named according to the input file and the construction parameters.
 Adding `-v` render 1D and 2D diagnostic images of the graph.
 (These are not enabled by default because they sometimes require manual configuration. Additionally, the 2D layout can take a while.)
@@ -132,7 +133,7 @@ cd pggb
 you can run the container using the example [human leukocyte antigen (HLA) data](data/HLA) provided in this repo:
 
 ```sh
-docker run -it -v ${PWD}/data/:/data ghcr.io/pangenome/pggb:latest "pggb -i /data/HLA/DRB1-3123.fa.gz -p 70 -s 3000 -G 2000 -n 10 -t 16 -v -V 'gi|568815561:#' -o /data/out -M -C cons,100,1000,10000 -m"
+docker run -it -v ${PWD}/data/:/data ghcr.io/pangenome/pggb:latest "pggb -i /data/HLA/DRB1-3123.fa.gz -p 70 -s 3000 -G 2000 -n 10 -t 16 -v -V 'gi|568815561:#' -o /data/out -M -m"
 ```
 
 The `-v` argument of `docker run` always expects a full path: `If you intended to pass a host directory, use absolute path.` This is taken care of by using `${PWD}`.
@@ -146,7 +147,7 @@ docker build --target binary -t ${USER}/pggb:latest .
 Staying in the `pggb` directory, we can run `pggb` with the locally build image:
 
 ```sh
-docker run -it -v ${PWD}/data/:/data ${USER}/pggb "pggb -i /data/HLA/DRB1-3123.fa.gz -p 70 -s 3000 -G 2000 -n 10 -t 16 -v -V 'gi|568815561:#' -o /data/out -M -C cons,100,1000,10000 -m"
+docker run -it -v ${PWD}/data/:/data ${USER}/pggb "pggb -i /data/HLA/DRB1-3123.fa.gz -p 70 -s 3000 -G 2000 -n 10 -t 16 -v -V 'gi|568815561:#' -o /data/out -M -m"
 ```
 #### Singularity
 
@@ -168,7 +169,7 @@ cd pggb
 Finally, run `pggb` from the Singularity image. For Singularity to be able to read and write files to a directory on the host operating system, we need to 'bind' that directory using the `-B` option and pass the `pggb` command as an argument.
 
 ```sh
-singularity run -B ${PWD}/data:/data ../pggb_latest.sif "pggb -i /data/HLA/DRB1-3123.fa.gz -p 70 -s 3000 -G 2000 -n 10 -t 16 -v -V 'gi|568815561:#' -o /data/out -M -C cons,100,1000,10000 -m"
+singularity run -B ${PWD}/data:/data ../pggb_latest.sif "pggb -i /data/HLA/DRB1-3123.fa.gz -p 70 -s 3000 -G 2000 -n 10 -t 16 -v -V 'gi|568815561:#' -o /data/out -M -m"
 ```
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,13 +20,13 @@ sys.path.insert(0, os.path.abspath('../lib/'))
 # -- Project information -----------------------------------------------------
 
 project = u'pggb'
-copyright = '2022, Erik Garrison, .... Revision v0.3.0-05df238'
+copyright = '2022, Erik Garrison, .... Revision v0.3.0-2235cfe'
 author = u'Erik Garrison, ...'
 
 # The short X.Y version
 version = 'v0.3.0'
 # The full version, including alpha/beta/rc tags
-release = '05df238'
+release = '2235cfe'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,10 +50,12 @@ Core packages
 
         + Global graph sorting with `PG-SGD <https://odgi.readthedocs.io/en/latest/rst/tutorials/sort_layout.html>`_
         + Break graph into blocks
-        + `smooth` blocks via `POA <https://simpsonlab.github.io/2015/05/01/understanding-poa/>`_
+        + Smooth blocks via `POA <https://simpsonlab.github.io/2015/05/01/understanding-poa/>`_
         + Graph has partial local order
         + Smoothed graph in `GFAv1 <https://github.com/GFA-spec/GFA-spec/blob/master/GFA1.md>`_ format
-        + Consensus  paths and graph
+..
+        + Consensus paths and graph
+
         + Whole genome alignment in `MAF <https://genome.ucsc.edu/FAQ/FAQformat.html#format5>`_ format
 
 

--- a/docs/rst/optional_parameters.rst
+++ b/docs/rst/optional_parameters.rst
@@ -108,7 +108,7 @@ Always set `-t` to the desired number of parallel threads. If the POA step of ``
 A  good approximation can be half what was set in ``-t``.
 
 ..
-    miscellancious
+    miscellaneous
 
     outdir
     input PAF

--- a/docs/rst/quick_start.rst
+++ b/docs/rst/quick_start.rst
@@ -54,8 +54,11 @@ We build a MHC class II ALTs GRCh38 pangenome graph from 10 haplotypes using tes
     cd pggb
     ./pggb -i data/HLA/DRB1-3123.fa.gz -p 70 -s 3000 -G 2000 -n 10 -t 16 -V 'gi|568815561:#' -o out -M -C cons,100,1000,10000 -m
 
-This writes to directory ``out``: A variation graph in GFA format, a multiple sequence alignment in MAF format, a series of consensus graphs at different levels of variant resolution, 
-and several diagnostic images. By default, the outputs are named according to the input file and a hash of the construction parameters. 
+..
+    This writes to directory ``out``: a variation graph in GFA format, a multiple sequence alignment in MAF format, a series of consensus graphs at different levels of variant resolution,
+
+This writes to directory ``out``: a variation graph in GFA format, a multiple sequence alignment in MAF format,
+and several diagnostic images. By default, the outputs are named according to the input file and a hash of the construction parameters.
 Adding -v prohibits the rendering of 1D and 2D diagnostic images of the graph. This can reduce running time, because the calculation of the 2D layout can take a while. 
 By default, redundant structures in the graph are collapsed by applying GFAffix. We also call variants with ``-V`` with respect to the reference ``gi|568815561:#``.
 

--- a/docs/rst/smoothxg.rst
+++ b/docs/rst/smoothxg.rst
@@ -11,5 +11,8 @@ With `smoothxg <https://github.com/pangenome/smoothxg>`_,  the graph is then sor
 topologically ordered locally. The 1D order is then broken into "blocks" which are "smoothed" using the partial order alignment (POA) algorithm 
 implemented in `abPOA <https://github.com/yangao07/abPOA>`_ or `spoa <https://github.com/rvaser/spoa>`_. This normalizes their mutual alignment 
 and removes artifacts resulting from transitive ambiguities in the pairwise alignments. It ensures that the graph always has local partial order, 
-which is essential for many applications and matches our prior expectations about small-scale variation in genomes. This step yields a rebuilt graph, 
-a consensus subgraph, and a whole genome alignment in `MAF <http://www.bx.psu.edu/~dcking/man/maf.xhtml>`_ format.
+which is essential for many applications and matches our prior expectations about small-scale variation in genomes.
+This step yields a rebuilt graph and a whole genome alignment in `MAF <http://www.bx.psu.edu/~dcking/man/maf.xhtml>`_ format.
+
+..
+    This step yields a rebuilt graph, a consensus subgraph, and a whole genome alignment in `MAF <http://www.bx.psu.edu/~dcking/man/maf.xhtml>`_ format.

--- a/pggb
+++ b/pggb
@@ -107,8 +107,14 @@ if [[
     || $n_mappings == false
    ]];
 then
-    show_help=true
-    >&2 echo "Mandatory arguments -i, -n"
+    >&2 echo "ERROR: mandatory arguments -i and -n"
+    exit
+fi
+
+if (( "$n_mappings" < 2 ));
+then
+    >&2 echo "ERROR: -n must be greater than or equal to 2"
+    exit
 fi
 
 if [[ $poa_threads == 0 ]];

--- a/pggb
+++ b/pggb
@@ -32,7 +32,7 @@ no_merge_segments=false
 do_stats=false
 exclude_delim=false
 write_maf=false
-consensus_spec=false
+consensus_spec=false # Disabled for the moment due to PGGB's #133 and #182 issues
 consensus_prefix=Consensus_
 no_splits=false
 multiqc=false
@@ -48,7 +48,7 @@ fi
 
 # read the options
 cmd=$0" "$@
-TEMP=`getopt -o i:o:a:p:n:s:l:K:k:f:B:H:j:P:O:Me:t:T:vhASY:G:C:Q:d:I:R:NrmZV: --long input-fasta:,output-dir:,input-paf:,map-pct-id:,n-mappings:,segment-length:,block-length-min:,mash-kmer:,min-match-length:,sparse-factor:,transclose-batch:,n-haps:,path-jump-max:,subpath-min:,edge-jump-max:,threads:,poa-threads:,skip-viz,do-layout,help,no-merge-segments,do-stats,exclude-delim:,poa-length-target:,poa-params:,poa-padding:,write-maf,consensus-spec:,consensus-prefix:,pad-max-depth:,block-id-min:,block-ratio-min:,no-splits,resume,keep-temp-files,multiqc,compress,vcf-spec: -n 'pggb' -- "$@"`
+TEMP=`getopt -o i:o:a:p:n:s:l:K:k:f:B:H:j:P:O:Me:t:T:vhASY:G:Q:d:I:R:NrmZV: --long input-fasta:,output-dir:,input-paf:,map-pct-id:,n-mappings:,segment-length:,block-length-min:,mash-kmer:,min-match-length:,sparse-factor:,transclose-batch:,n-haps:,path-jump-max:,subpath-min:,edge-jump-max:,threads:,poa-threads:,skip-viz,do-layout,help,no-merge-segments,do-stats,exclude-delim:,poa-length-target:,poa-params:,poa-padding:,write-maf,consensus-spec:,consensus-prefix:,pad-max-depth:,block-id-min:,block-ratio-min:,no-splits,resume,keep-temp-files,multiqc,compress,vcf-spec: -n 'pggb' -- "$@"`
 eval set -- "$TEMP"
 
 # extract options and their arguments into variables.
@@ -75,7 +75,7 @@ while true ; do
         -P|--poa-params) poa_params=$2 ; shift 2 ;;
         -O|--poa-padding) poa_padding=$2 ; shift 2 ;;
         -M|--write-maf) write_maf=true ; shift ;;
-        -C|--consensus-spec) consensus_spec=$2 ; shift 2 ;;
+        #-C|--consensus-spec) consensus_spec=$2 ; shift 2 ;;
         -Q|--consensus-prefix) consensus_prefix=$2 ; shift 2 ;;
         -t|--threads) threads=$2 ; shift 2 ;;
         -T|--poa-threads) poa_threads=$2 ; shift 2 ;;
@@ -196,15 +196,15 @@ then
     echo "    -d, --pad-max-depth N       depth/haplotype at which we don't pad the POA problem [default: 100]"
     echo "    -M, --write-maf             write MAF output representing merged POA blocks [default: off]"
     echo "    -Q, --consensus-prefix P    use this prefix for consensus path names [default: Consensus_]"
-    echo "    -C, --consensus-spec SPEC   consensus graph specification: write consensus graphs to"
-    echo "                                BASENAME.cons_[spec].gfa; where each spec contains at least a min_len parameter"
-    echo "                                (which defines the length of divergences from consensus paths to preserve in the"
-    echo "                                output), optionally a file containing reference paths to preserve in the output,"
-    echo "                                a flag (y/n) indicating whether we should also use the POA consensus paths, a"
-    echo "                                minimum coverage of consensus paths to retain (min_cov), and a maximum allele"
-    echo "                                length (max_len, defaults to 1e6); implies -a; example:"
-    echo "                                cons,100,1000:refs1.txt:n,1000:refs2.txt:y:2.3:1000000,10000"
-    echo "                                [default: off]"
+    #echo "    -C, --consensus-spec SPEC   consensus graph specification: write consensus graphs to"
+    #echo "                                BASENAME.cons_[spec].gfa; where each spec contains at least a min_len parameter"
+    #echo "                                (which defines the length of divergences from consensus paths to preserve in the"
+    #echo "                                output), optionally a file containing reference paths to preserve in the output,"
+    #echo "                                a flag (y/n) indicating whether we should also use the POA consensus paths, a"
+    #echo "                                minimum coverage of consensus paths to retain (min_cov), and a maximum allele"
+    #echo "                                length (max_len, defaults to 1e6); implies -a; example:"
+    #echo "                                cons,100,1000:refs1.txt:n,1000:refs2.txt:y:2.3:1000000,10000"
+    #echo "                                [default: off]"
     echo "   [odgi]"
     echo "    -v, --skip-viz              don't render visualizations of the graph in 1D and 2D [default: make them]"
     echo "    -S, --stats                 generate statistics of the seqwish and smoothxg graph [default: off]"
@@ -234,7 +234,8 @@ fi
 
 # Alignment
 mapper_letter='W'
-paf_spec=$mapper_letter-s$segment_length-l$block_length-p$map_pct_id-n$n_mappings-K$mash_kmer
+n_mappings_minus_1=$( echo "$n_mappings - 1" | bc )
+paf_spec=$mapper_letter-s$segment_length-l$block_length-p$map_pct_id-n$n_mappings_minus_1-K$mash_kmer
 
 if [[ $no_merge_segments == true ]];
 then
@@ -349,7 +350,7 @@ if [[ ! -s $prefix_paf.$mapper.paf || $resume == false ]]; then
               $split_cmd \
               $mash_kmer_cmd \
               -p $map_pct_id \
-              -n $n_mappings \
+              -n $n_mappings_minus_1 \
               -t $threads \
               "$input_fasta" "$input_fasta" \
               > "$prefix_paf".$mapper.paf) 2> >(tee -a "$log_file")


### PR DESCRIPTION
In `pggb`, `-n` is the number of haplotypes/genomes in the input dataset.
In `wfmash`, `-n` is the maximum number of mappings to consider for each homologous region identified in the input dataset. To avoid overlapping (relevant for small datasets), `wfmash -n` has to be set as `pggb -n` minus 1.

Furthermore, consensus graph generation has been disabled (due to #133 and #182 issues) and it will be for a while.