### PR TITLE
Crazy up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update \
 RUN git clone --recursive https://github.com/waveygang/wfmash \
     && cd wfmash \
     && git pull \
-    && git checkout 2f33ff55702f89fed3f7cc4c7e9478462f49dd8c \
+    && git checkout 19234a4a153ea3f3acce6f4ac192afc70bbb7fda \
     && git submodule update --init --recursive \
     && cmake -H. -DCMAKE_BUILD_TYPE=Generic -Bbuild && cmake --build build -- -j $(nproc) \
     && cp build/bin/wfmash /usr/local/bin/wfmash \
@@ -57,7 +57,7 @@ RUN git clone --recursive https://github.com/ekg/seqwish \
 RUN git clone --recursive https://github.com/pangenome/smoothxg \
     && cd smoothxg \
     && git pull \
-    && git checkout eebb7b583ea3bde18bb22b70bd90dc96a23a4703 \
+    && git checkout 87264898fa81fbac4602d51a9840186bb82f4da1 \
     && git submodule update --init --recursive \
     && sed -i 's/-march=native/-march=haswell/g' deps/abPOA/CMakeLists.txt \
     && cmake -H. -DCMAKE_BUILD_TYPE=Generic -Bbuild && cmake --build build -- -j $(nproc) \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update \
 RUN git clone --recursive https://github.com/waveygang/wfmash \
     && cd wfmash \
     && git pull \
-    && git checkout b277f1ae6796c9cc1ba360fe57bcc92d819f29c7 \
+    && git checkout 2f33ff55702f89fed3f7cc4c7e9478462f49dd8c \
     && git submodule update --init --recursive \
     && cmake -H. -DCMAKE_BUILD_TYPE=Generic -Bbuild && cmake --build build -- -j $(nproc) \
     && cp build/bin/wfmash /usr/local/bin/wfmash \
@@ -57,7 +57,7 @@ RUN git clone --recursive https://github.com/ekg/seqwish \
 RUN git clone --recursive https://github.com/pangenome/smoothxg \
     && cd smoothxg \
     && git pull \
-    && git checkout 20fee54d5279dd8bb435fb95b93b386cc5eec997 \
+    && git checkout eebb7b583ea3bde18bb22b70bd90dc96a23a4703 \
     && git submodule update --init --recursive \
     && sed -i 's/-march=native/-march=haswell/g' deps/abPOA/CMakeLists.txt \
     && cmake -H. -DCMAKE_BUILD_TYPE=Generic -Bbuild && cmake --build build -- -j $(nproc) \

--- a/pggb
+++ b/pggb
@@ -472,7 +472,7 @@ do
                    $poa_params_cmd \
                    -O $poa_padding \
                    -Y $(echo "$pad_max_depth * $n_haps" | bc) \
-                   -d 0 -D 0 \
+                   -d 0 -D 0 -S \
                    -V \
                    -o "$prefix_smoothed".$i.gfa \
                    2> >(tee -a "$log_file")
@@ -498,7 +498,7 @@ do
                    $poa_params_cmd \
                    -O $poa_padding \
                    -Y $(echo "$pad_max_depth * $n_haps" | bc) \
-                   -d 0 -D 0 \
+                   -d 0 -D 0 -S \
                    $maf_params \
                    -Q $consensus_prefix \
                    $consensus_params \

--- a/pggb
+++ b/pggb
@@ -10,7 +10,7 @@ input_paf=false
 resume=false
 map_pct_id=95
 n_mappings=false
-segment_length=10000
+segment_length=1000
 block_length=false
 sparse_map=false
 mash_kmer=false
@@ -174,7 +174,7 @@ if [ $show_help ]; then
     echo "options:"
     echo "   [wfmash]"
     echo "    -i, --input-fasta FILE      input FASTA/FASTQ file"
-    echo "    -s, --segment-length N      segment length for mapping [default: 10k]"
+    echo "    -s, --segment-length N      segment length for mapping [default: 1k]"
     echo "    -l, --block-length N        minimum block length filter for mapping [default: 5*segment-length]"
     echo "    -N, --no-split              disable splitting of input sequences during mapping [enabled by default]"
     echo "    -p, --map-pct-id PCT        percent identity for mapping/alignment [default: 95]"


### PR DESCRIPTION
Improvement of wfmash's chaining model and high level wavefront reduction allow us to apply a smaller segment size. This improves sensitivity to inversions and larger structural variant breakpoints.

At the same time, we resolve a long-standing problem with smoothxg. We applied abPOA in global mode. This yields excellent runtime performance, but it can cause "accordions" in the graphs, which are characterized by runs of SNPs and indels. In effect, these are regions that are only aligned together because of our use of global alignment. Applying local alignment previously led to longer runtime (which was problematic) and also underaligned regions. By iterating smoothxg twice, we mitigate underalignment issues.

Basically, we were stuck in a suboptimal configuration using global alignment, but improvements to wfmash and the progressive application of smoothxg seem to have resolved these, allowing us to use local abPOA.