### PR TITLE
Emit tools' version in the LOG/YAML output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update \
 RUN git clone --recursive https://github.com/waveygang/wfmash \
     && cd wfmash \
     && git pull \
-    && git checkout cf9bfb0ef9fe5b973b91ee3aa649533df7521557 \
+    && git checkout 5791c12591bb0445c28e39c8bf19ac23aa366a06 \
     && git submodule update --init --recursive \
     && sed -i 's/-march=native/-march=haswell/g' src/common/wflign/deps/WFA2-lib/Makefile \
     && cmake -H. -DCMAKE_BUILD_TYPE=Generic -Bbuild && cmake --build build -- -j $(nproc) \
@@ -55,7 +55,7 @@ RUN git clone --recursive https://github.com/waveygang/wfmash \
 RUN git clone --recursive https://github.com/ekg/seqwish \
     && cd seqwish \
     && git pull \
-    && git checkout 3dc2a43ae32cd823875dc583e0e064ba1179f725 \
+    && git checkout f362f6f5ea89dbb6a0072a8b8ba215e663301d33 \
     && git submodule update --init --recursive \
     && cmake -H. -DCMAKE_BUILD_TYPE=Generic -DEXTRA_FLAGS='-march=haswell' -Bbuild && cmake --build build -- -j $(nproc) \
     && cp bin/seqwish /usr/local/bin/seqwish \
@@ -65,7 +65,7 @@ RUN git clone --recursive https://github.com/ekg/seqwish \
 RUN git clone --recursive https://github.com/pangenome/smoothxg \
     && cd smoothxg \
     && git pull \
-    && git checkout 478941826b0ef6a2570acc308312f6b209c16c97 \
+    && git checkout 0c04e302d2c2c0c6a01dbd1519870d2bf986733f \
     && git submodule update --init --recursive \
     && sed -i 's/-msse4.1/-march=haswell/g' deps/spoa/CMakeLists.txt \
     && sed -i 's/-march=native/-march=haswell/g' deps/spoa/CMakeLists.txt \
@@ -84,7 +84,7 @@ RUN cargo --help
 RUN git clone https://github.com/marschall-lab/GFAffix.git \
     && cd GFAffix \
     && git pull \
-    && git checkout 5412bb1571ad22a72c374a628a097322d8303758 \
+    && git checkout ff282ca53ed53337e22eabc3b41e86df6ca0dc66 \
     && cargo install --force --path . \
     && mv /root/.cargo/bin/gfaffix /usr/local/bin/gfaffix \
     && cd ../ \
@@ -105,7 +105,7 @@ RUN git clone https://github.com/pangenome/vcfbub \
 
 RUN git clone --recursive https://github.com/vcflib/vcflib.git \
     && cd vcflib \
-    && git checkout d6e2400923402d2f41db6040a9c91bff6930c4e3 \
+    && git checkout 8ec06d899492738e7db21bfb1168273afdaaf1fb \
     && mkdir -p build \
     && cd build \
     && cmake -DZIG=OFF -DCMAKE_BUILD_TYPE=Debug .. && cmake --build . -- -j $(nproc) \

--- a/partition-before-pggb
+++ b/partition-before-pggb
@@ -425,6 +425,7 @@ vg:
   version:            $(vg version | head -n 1 | cut -f 3 -d ' ')
   deconstruct:        $vcf_spec
 reporting:
+  version:            v$(multiqc --version | cut -f 3 -d ' ')
   multiqc:            $multiqc
 EOT
 

--- a/partition-before-pggb
+++ b/partition-before-pggb
@@ -245,9 +245,11 @@ fi
 # Alignment
 if [[ $input_paf == false ]]; then
   mapper=wfmash
+  mapper_version=$(wfmash --version 2>&1)
   mapper_letter='W'
 else
   mapper=external
+  mapper_version=unknown
   mapper_letter='E'
 fi
 
@@ -377,8 +379,8 @@ general:
   compress:           $compress
   threads:            $threads
   poa_threads:        $poa_threads
-wfmash:
-  mapping-tool:       $mapper
+$mapper:
+  version:            $mapper_version
   segment-length:     $segment_length
   block-length:       $block_length
   map-pct-id:         $map_pct_id
@@ -390,10 +392,12 @@ wfmash:
   exclude-delim:      $exclude_delim
   no-merge-segments:  $no_merge_segments
 seqwish:
+  version:            $(seqwish --version 2>&1)
   min-match-len:      $min_match_length
   sparse-factor:      $sparse_factor
   transclose-batch:   $transclose_batch
 smoothxg:
+  version:            $(smoothxg --version 2>&1)
   skip-normalization: $skip_normalization
   n-haps:             $n_haps
   path-jump-max:      $max_path_jump
@@ -410,14 +414,18 @@ smoothxg:
   block-id-min:       $block_id_min
   block-ratio-min:    $block_ratio_min
 odgi:
+  version:            $(odgi version -v 2>&1)
   viz:                $do_viz
   layout:             $do_layout
   stats:              $do_stats
 gfaffix:
+  version:            v$(gfaffix --version | cut -f 2 -d ' ')
   reduce-redundancy:  $reduce_redundancy
 vg:
+  version:            $(vg version | head -n 1 | cut -f 3 -d ' ')
   deconstruct:        $vcf_spec
 reporting:
+  version:            v$(multiqc --version | cut -f 3 -d ' ')
   multiqc:            $multiqc
 EOT
 

--- a/partition-before-pggb
+++ b/partition-before-pggb
@@ -425,7 +425,6 @@ vg:
   version:            $(vg version | head -n 1 | cut -f 3 -d ' ')
   deconstruct:        $vcf_spec
 reporting:
-  version:            v$(multiqc --version | cut -f 3 -d ' ')
   multiqc:            $multiqc
 EOT
 

--- a/pggb
+++ b/pggb
@@ -149,7 +149,7 @@ done
 if [ $show_version == true ]; then
     SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
     cd "$SCRIPT_DIR"
-    GIT_VERSION=$(git describe --always --tags)
+    GIT_VERSION=$(git describe --always --tags --long)
     echo "pggb $GIT_VERSION"
     cd - &> /dev/null
     exit

--- a/pggb
+++ b/pggb
@@ -424,7 +424,6 @@ vg:
   version:            $(vg version | head -n 1 | cut -f 3 -d ' ')
   deconstruct:        $vcf_spec
 reporting:
-  version:            v$(multiqc --version | cut -f 3 -d ' ')
   multiqc:            $multiqc
 EOT
 

--- a/pggb
+++ b/pggb
@@ -245,9 +245,11 @@ fi
 # Alignment
 if [[ $input_paf == false ]]; then
   mapper=wfmash
+  mapper_version=$(wfmash --version 2>&1)
   mapper_letter='W'
 else
   mapper=external
+  mapper_version=unknown
   mapper_letter='E'
 fi
 
@@ -376,8 +378,8 @@ general:
   compress:           $compress
   threads:            $threads
   poa_threads:        $poa_threads
-wfmash:
-  mapping-tool:       $mapper
+$mapper:
+  version:            $mapper_version
   segment-length:     $segment_length
   block-length:       $block_length
   map-pct-id:         $map_pct_id
@@ -389,10 +391,12 @@ wfmash:
   exclude-delim:      $exclude_delim
   no-merge-segments:  $no_merge_segments
 seqwish:
+  version:            $(seqwish --version 2>&1)
   min-match-len:      $min_match_length
   sparse-factor:      $sparse_factor
   transclose-batch:   $transclose_batch
 smoothxg:
+  version:            $(smoothxg --version 2>&1)
   skip-normalization: $skip_normalization
   n-haps:             $n_haps
   path-jump-max:      $max_path_jump
@@ -409,14 +413,18 @@ smoothxg:
   block-id-min:       $block_id_min
   block-ratio-min:    $block_ratio_min
 odgi:
+  version:            $(odgi version -v 2>&1)
   viz:                $do_viz
   layout:             $do_layout
   stats:              $do_stats
 gfaffix:
+  version:            v$(gfaffix --version | cut -f 2 -d ' ')
   reduce-redundancy:  $reduce_redundancy
 vg:
+  version:            $(vg version | head -n 1 | cut -f 3 -d ' ')
   deconstruct:        $vcf_spec
 reporting:
+  version:            v$(multiqc --version | cut -f 3 -d ' ')
   multiqc:            $multiqc
 EOT
 

--- a/pggb
+++ b/pggb
@@ -424,6 +424,7 @@ vg:
   version:            $(vg version | head -n 1 | cut -f 3 -d ' ')
   deconstruct:        $vcf_spec
 reporting:
+  version:            v$(multiqc --version | cut -f 3 -d ' ')
   multiqc:            $multiqc
 EOT
 


### PR DESCRIPTION
This helps reproducibility and debugging.

```
Starting pggb on 11-10-2022_09:59:47

Command: /home/guarracino/git/pggb/pggb -i data/HLA/DRB1-3123.fa.gz -p 70 -s 3000 -G 2000 -n 10 -o drib1

PARAMETERS

general:
  input-fasta:        data/HLA/DRB1-3123.fa.gz
  output-dir:         drib1
  temp-dir:           drib1
  resume:             false
  compress:           false
  threads:            12
  poa_threads:        12
wfmash:
  version:            v0.10.0-6-g5791c12
  segment-length:     3000
  block-length:       25000
  map-pct-id:         70
  n-mappings:         10
  no-splits:          false
  sparse-map:         false
  mash-kmer:          19
  mash-kmer-thres:    0.001
  exclude-delim:      false
  no-merge-segments:  false
seqwish:
  version:            v0.7.7-2-gf362f6f
  min-match-len:      19
  sparse-factor:      0
  transclose-batch:   10000000
smoothxg:
  version:            v0.6.7-5-g0c04e30
  skip-normalization: false
  n-haps:             10
  path-jump-max:      0
  edge-jump-max:      0
  poa-length-target:  2000
  poa-params:         1,19,39,3,81,1
  poa_padding:        0.001
  run_abpoa:          false
  run_global_poa:     false
  pad-max-depth:      100
  write-maf:          false
  consensus-spec:     false
  consensus-prefix:   Consensus_
  block-id-min:       .7000
  block-ratio-min:    0
odgi:
  version:            v0.8.1-4-gc8717fc
  viz:                true
  layout:             true
  stats:              false
gfaffix:
  version:            v0.1.4
  reduce-redundancy:  true
vg:
  version:            v1.43.0
  deconstruct:        false
reporting:
  version:            v1.11
  multiqc:            false

Running pggb

...
```