### PR TITLE
Scripts folder added to /usr/local/bin/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,6 +142,8 @@ RUN chmod 777 /usr/local/bin/pggb
 COPY partition-before-pggb /usr/local/bin/partition-before-pggb
 RUN chmod a+rx /usr/local/bin/partition-before-pggb
 
+COPY scripts /usr/local/bin/scripts
+
 # Hacky-way to easily get versioning info
 COPY .git /usr/local/bin/
 


### PR DESCRIPTION
Hi,

I've found that the scripts folder was missing to make partition-before-pggb work ;) 

I think it would be mandatory for pggb also.

Hope it'll help

best regards