### PR TITLE
update smoothxg to perform the POA on unique sequences

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN git clone --recursive https://github.com/ekg/seqwish \
 RUN git clone --recursive https://github.com/pangenome/smoothxg \
     && cd smoothxg \
     && git pull \
-    && git checkout c12f2d2685e566fe04868fd4749e544eb5a6bc37 \
+    && git checkout 6ecefd518710195d33c2d839eb8b86139e9b1146 \
     && git submodule update --init --recursive \
     && sed -i 's/-msse4.1/-march=sandybridge -Ofast/g' deps/spoa/CMakeLists.txt \
     && sed -i 's/-march=native/-march=sandybridge -Ofast/g' deps/spoa/CMakeLists.txt \

--- a/pggb
+++ b/pggb
@@ -512,9 +512,9 @@ if [[ $skip_normalization == false ]]; then
       keep_temp_cmd="-K"
   fi
 
-  smoothxg_xpoa_cmd="-S"
+  smoothxg_xpoa_cmd=""
   if [[ "$run_abpoa" == true ]]; then
-    smoothxg_xpoa_cmd=""
+    smoothxg_xpoa_cmd="-A"
   fi
 
   smoothxg_poa_mode_cmd=""


### PR DESCRIPTION
On average, this speeds up `smoothxg` by about 5X. In difficult cases, it goes much, much faster (see https://github.com/pangenome/smoothxg/pull/183).