### PR TITLE
Fix versioning

### DIFF
--- a/.github/workflows/build_and_test_docker.yml
+++ b/.github/workflows/build_and_test_docker.yml
@@ -10,10 +10,10 @@ jobs:
       - name: Build the Docker image
         run: docker build . --file Dockerfile --target binary --tag pggb
       - name: Run a test on the DRB1-3123 dataset (SPOA)
-        run: docker run -v ${PWD}/data/:/data pggb /bin/bash -c "pggb -i data/HLA/DRB1-3123.fa.gz -p 70 -s 3000 -G 800,900,1100 -n 10 -t 2 -Z -V 'gi|568815561:#,gi|29124352:#:10000' -M -m -o drib1_spoa && ls drib1_spoa/*"
+        run: docker run -v ${PWD}/data/:/data pggb /bin/bash -c "pggb -i data/HLA/DRB1-3123.fa.gz -p 70 -s 3000 -G 800,900,1100 -n 10 -t 2 -Z -V 'gi|568815561:#,gi|29124352:#:10000' -M -m -o drib1_spoa && ls drib1_spoa/* && head drib1_spoa/*.log -n 63"
       - name: Run a test on the DRB1-3123 dataset (abPOA)
-        run: docker run -v ${PWD}/data/:/data pggb /bin/bash -c "pggb -i data/HLA/DRB1-3123.fa.gz -p 70 -s 3000 -G 800,900,1100 -n 10 -t 2 -Z -V 'gi|568815561:#,gi|29124352:#:10000' -M -m -b -o drib1_abpoa && ls drib1_abpoa/*"
+        run: docker run -v ${PWD}/data/:/data pggb /bin/bash -c "pggb -i data/HLA/DRB1-3123.fa.gz -p 70 -s 3000 -G 800,900,1100 -n 10 -t 2 -Z -V 'gi|568815561:#,gi|29124352:#:10000' -M -m -b -o drib1_abpoa && ls drib1_abpoa/* && head drib1_abpoa/*.log -n 63"
       - name: Run a test on the DRB1-3123 dataset (paf)
-        run: docker run -v ${PWD}/data/:/data pggb /bin/bash -c "pggb -i data/HLA/DRB1-3123.fa.gz -a data/paf/DRB1-3123.fa.15a1009.wfmash.paf -p 70 -s 3000 -G 2000 -n 10 -t 2 -Z -V 'gi|568815561:#,gi|29124352:#' -M -m -o drib1_paf && ls drib1_paf/*"
+        run: docker run -v ${PWD}/data/:/data pggb /bin/bash -c "pggb -i data/HLA/DRB1-3123.fa.gz -a data/paf/DRB1-3123.fa.15a1009.wfmash.paf -p 70 -s 3000 -G 2000 -n 10 -t 2 -Z -V 'gi|568815561:#,gi|29124352:#' -M -m -o drib1_paf && ls drib1_paf/* && head drib1_paf/*.log -n 63"
       - name: Run a test on the LPA dataset (SPOA global)
-        run: docker run -v ${PWD}/data/:/data pggb /bin/bash -c "pggb -i data/LPA/LPA.fa.gz -p 95 -s 20000 -G 800,900 -n 90 -k 79 -t 2 -Z -O 0.001 -m -z -o lpa && ls lpa/*"
+        run: docker run -v ${PWD}/data/:/data pggb /bin/bash -c "pggb -i data/LPA/LPA.fa.gz -p 95 -s 20000 -G 800,900 -n 90 -k 79 -t 2 -Z -O 0.001 -m -z -o lpa && ls lpa/* && head drib1_paf/*.log -n 63"

--- a/.github/workflows/build_and_test_docker.yml
+++ b/.github/workflows/build_and_test_docker.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Run a test on the DRB1-3123 dataset (paf)
         run: docker run -v ${PWD}/data/:/data pggb /bin/bash -c "pggb -i data/HLA/DRB1-3123.fa.gz -a data/paf/DRB1-3123.fa.15a1009.wfmash.paf -p 70 -s 3000 -G 2000 -n 10 -t 2 -Z -V 'gi|568815561:#,gi|29124352:#' -M -m -o drib1_paf && ls drib1_paf/* && head drib1_paf/*.log -n 63"
       - name: Run a test on the LPA dataset (SPOA global)
-        run: docker run -v ${PWD}/data/:/data pggb /bin/bash -c "pggb -i data/LPA/LPA.fa.gz -p 95 -s 20000 -G 800,900 -n 90 -k 79 -t 2 -Z -O 0.001 -m -z -o lpa && ls lpa/* && head drib1_paf/*.log -n 63"
+        run: docker run -v ${PWD}/data/:/data pggb /bin/bash -c "pggb -i data/LPA/LPA.fa.gz -p 95 -s 20000 -G 800,900 -n 90 -k 79 -t 2 -Z -O 0.001 -m -z -o lpa && ls lpa/* && head lpa/*.log -n 63"

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN git clone --recursive https://github.com/ekg/seqwish \
 RUN git clone --recursive https://github.com/pangenome/smoothxg \
     && cd smoothxg \
     && git pull \
-    && git checkout e4c1149141ceb896740a8831a5e35fa65b7ba238 \
+    && git checkout 6e2f8c0d7eeccb2814f43cb19b27c33665739042 \
     && git submodule update --init --recursive \
     && sed -i 's/-msse4.1/-march=sandybridge -Ofast/g' deps/spoa/CMakeLists.txt \
     && sed -i 's/-march=native/-march=sandybridge -Ofast/g' deps/spoa/CMakeLists.txt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update \
 RUN git clone --recursive https://github.com/waveygang/wfmash \
     && cd wfmash \
     && git pull \
-    && git checkout 2aaba270406b3088bca2a5ed61f2c8105db25c72 \
+    && git checkout b310bd1c3b26da0c63dfeba77bf68a0835a2ff9b \
     && git submodule update --init --recursive \
     && sed -i 's/-march=native/-march=sandybridge/g' src/common/wflign/deps/WFA2-lib/Makefile \
     && cmake -H. -DCMAKE_BUILD_TYPE=Generic -DEXTRA_FLAGS='-march=sandybridge -Ofast' -Bbuild && cmake --build build -- -j $(nproc) \
@@ -55,7 +55,7 @@ RUN git clone --recursive https://github.com/waveygang/wfmash \
 RUN git clone --recursive https://github.com/ekg/seqwish \
     && cd seqwish \
     && git pull \
-    && git checkout f362f6f5ea89dbb6a0072a8b8ba215e663301d33 \
+    && git checkout a9c39bbdaf657822213bb76fb279182b24a38f00 \
     && git submodule update --init --recursive \
     && cmake -H. -DCMAKE_BUILD_TYPE=Generic -DEXTRA_FLAGS='-march=sandybridge -Ofast' -Bbuild && cmake --build build -- -j $(nproc) \
     && cp bin/seqwish /usr/local/bin/seqwish \


### PR DESCRIPTION
See https://github.com/pangenome/odgi/pull/482 and https://github.com/pangenome/smoothxg/pull/186.

Docker/Singularity images of PGGB display the wrong version of `odgi`. The `odgi` binary is correct, only the version it shows is wrong. In PGGB we use the `odgi` compiled with `smoothxg` and there the script to catch `odgi`'s version wrongly calls `smoothgx`'s git, not `odgi`'s.