### PR TITLE
update smoothxg to avoid uncovered edges

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN git clone --recursive https://github.com/ekg/seqwish \
 RUN git clone --recursive https://github.com/pangenome/smoothxg \
     && cd smoothxg \
     && git pull \
-    && git checkout d9adcfa21436c738f8f9ceea28643a81e606b757 \
+    && git checkout 4ff4cf2487afca5629c55ec38c977106ff08001b \
     && git submodule update --init --recursive \
     && sed -i 's/-msse4.1/-march=sandybridge -Ofast/g' deps/spoa/CMakeLists.txt \
     && sed -i 's/-march=native/-march=sandybridge -Ofast/g' deps/spoa/CMakeLists.txt \


### PR DESCRIPTION
SPOA and abPOA introduce links not supported by any path, leading to graphs with uncovered edges (see https://github.com/pangenome/pggb/issues/299). This PR avoids that and should fix https://github.com/pangenome/pggb/issues/299. Moreover, it adds a tiny optimization in case there are no blocks to flip.