### PR TITLE
handle version reporting if pggb is symlinked

### DIFF
--- a/pggb
+++ b/pggb
@@ -169,7 +169,7 @@ while true ; do
 done
 
 if [ $show_version == true ]; then
-    SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+    SCRIPT_DIR=$( cd -- "$(dirname -- "$(readlink -f "${BASH_SOURCE[0]}" )" )" &> /dev/null && pwd )
     cd "$SCRIPT_DIR"
     GIT_VERSION=$(git describe --always --tags --long)
     echo "pggb $GIT_VERSION"


### PR DESCRIPTION
symlinking `pggb` and asking for verison would report that there is no git repo. Here we read through the symlinked directory source, so we can still report pggb's version correctly.