### PR TITLE
`vg deconstruct` 1.40.0 (again) and sort decomposed VCF file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ RUN git clone https://github.com/marschall-lab/GFAffix.git \
 
 RUN pip install multiqc==1.18
 
-RUN wget https://github.com/vgteam/vg/releases/download/v1.53.0/vg && chmod +x vg && mv vg /usr/local/bin/vg
+RUN wget https://github.com/vgteam/vg/releases/download/v1.40.0/vg && chmod +x vg && mv vg /usr/local/bin/vg
 
 RUN git clone https://github.com/pangenome/vcfbub \
     && cd vcfbub \

--- a/pggb
+++ b/pggb
@@ -669,7 +669,7 @@ if [[ $vcf_spec != false ]]; then
 
             #TODO: remove "bcftools annotate" when vcfwave will be bug-free.
             # The TYPE info sometimes is wrong/missing and there are variants without the ALT allele.
-            bcftools sort -T "$temp_dir" | bcftools annotate -x INFO/TYPE "$vcf_decomposed_tmp"  | awk '$5 != "."' > "$vcf_decomposed"
+            bcftools sort -T "$temp_dir" "$vcf_decomposed_tmp" | bcftools annotate -x INFO/TYPE | awk '$5 != "."' > "$vcf_decomposed"
             rm "$vcf_decomposed_tmp" "$vcf".gz
 
             bcftools stats "$vcf_decomposed" > "$vcf_decomposed".stats

--- a/pggb
+++ b/pggb
@@ -667,10 +667,9 @@ if [[ $vcf_spec != false ]]; then
             bgzip -c -@ $threads "$vcf" > "$vcf".gz
             TEMPDIR=$(pwd) $timer -f "$fmt" vcfbub -l 0 -a $pop_length --input "$vcf".gz | TEMPDIR=$(pwd) $timer -f "$fmt" vcfwave -I 1000 -t $threads > "$vcf_decomposed_tmp"
 
-            #TODO: to remove when vcfwave will be bug-free
-            # The TYPE info sometimes is wrong/missing
-            # There are variants without the ALT allele
-            bcftools annotate -x INFO/TYPE "$vcf_decomposed_tmp"  | awk '$5 != "."' > "$vcf_decomposed"
+            #TODO: remove "bcftools annotate" when vcfwave will be bug-free.
+            # The TYPE info sometimes is wrong/missing and there are variants without the ALT allele.
+            bcftools sort -T "$temp_dir" | bcftools annotate -x INFO/TYPE "$vcf_decomposed_tmp"  | awk '$5 != "."' > "$vcf_decomposed"
             rm "$vcf_decomposed_tmp" "$vcf".gz
 
             bcftools stats "$vcf_decomposed" > "$vcf_decomposed".stats


### PR DESCRIPTION
The decomposed VCF file was not guaranteed to be sorted. Now it is.

Moreover, we go back to `vg deconstruct` 1.40.0 as newer versions still present issues with empty genotypes in the outputs.