### PR TITLE
multiqc 1.21, bcftools 1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,13 @@ RUN apt-get update \
     && apt-get purge  \
     && rm -rf /var/lib/apt/lists/*
 
+# current bcftools
+RUN wget https://github.com/samtools/bcftools/releases/download/1.19/bcftools-1.19.tar.bz2 \
+    && tar xjf bcftools-1.19.tar.bz2 \
+    && cd bcftools-1.19/ && ./configure --prefix=/usr/local/bin/ && make && make install && export PATH=/usr/local/bin/bin:$PATH && cd .. && cp /usr/local/bin/bin/* /usr/local/bin/
+
+RUN bcftools
+
 RUN git clone --recursive https://github.com/waveygang/wfmash \
     && cd wfmash \
     && git pull \
@@ -176,13 +183,6 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key B8F25A8A73E
 RUN wget https://github.com/arq5x/bedtools2/releases/download/v2.31.0/bedtools.static \
     && mv bedtools.static /usr/local/bin/bedtools \
     && chmod +x /usr/local/bin/bedtools
-
-# current bcftools
-RUN wget https://github.com/samtools/bcftools/releases/download/1.19/bcftools-1.19.tar.bz2 \
-    && tar xjf bcftools-1.19.tar.bz2 \
-    && cd bcftools-1.19/ && ./configure --prefix=/usr/local/bin/ && make && make install && export PATH=/usr/local/bin/bin:$PATH && cd .. && cp /usr/local/bin/bin/* /usr/local/bin/
-
-RUN bcftools
 
 # copy required scripts
 COPY scripts/* /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ RUN apt-get update \
                        curl \
                        pigz \
                        tabix \
-                       bcftools \
                        samtools \
                        wget \
                        pip \
@@ -97,7 +96,7 @@ RUN git clone https://github.com/marschall-lab/GFAffix.git \
     && cd ../ \
     && rm -rf GFAffix
 
-RUN pip install multiqc==1.18
+RUN pip install multiqc==1.21
 
 RUN wget https://github.com/vgteam/vg/releases/download/v1.40.0/vg && chmod +x vg && mv vg /usr/local/bin/vg
 
@@ -177,6 +176,11 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key B8F25A8A73E
 RUN wget https://github.com/arq5x/bedtools2/releases/download/v2.31.0/bedtools.static \
     && mv bedtools.static /usr/local/bin/bedtools \
     && chmod +x /usr/local/bin/bedtools
+
+# current bcftools
+RUN wget https://github.com/samtools/bcftools/releases/download/1.19/bcftools-1.19.tar.bz2 \
+    && tar xjf bcftools-1.19.tar.bz2 \
+    && bcftools-1.19/ && ./configure --prefix=/usr/local/bin/ && make && make install && export PATH=/usr/local/bin/bin:$PATH
 
 # copy required scripts
 COPY scripts/* /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -182,6 +182,8 @@ RUN wget https://github.com/samtools/bcftools/releases/download/1.19/bcftools-1.
     && tar xjf bcftools-1.19.tar.bz2 \
     && bcftools-1.19/ && ./configure --prefix=/usr/local/bin/ && make && make install && export PATH=/usr/local/bin/bin:$PATH
 
+RUN bcftools
+
 # copy required scripts
 COPY scripts/* /usr/local/bin/
 COPY scripts /usr/local/bin/scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -180,7 +180,7 @@ RUN wget https://github.com/arq5x/bedtools2/releases/download/v2.31.0/bedtools.s
 # current bcftools
 RUN wget https://github.com/samtools/bcftools/releases/download/1.19/bcftools-1.19.tar.bz2 \
     && tar xjf bcftools-1.19.tar.bz2 \
-    && bcftools-1.19/ && ./configure --prefix=/usr/local/bin/ && make && make install && export PATH=/usr/local/bin/bin:$PATH
+    && cd bcftools-1.19/ && ./configure --prefix=/usr/local/bin/ && make && make install && export PATH=/usr/local/bin/bin:$PATH && cd ..
 
 RUN bcftools
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,6 @@ RUN wget https://github.com/samtools/bcftools/releases/download/1.19/bcftools-1.
     && tar xjf bcftools-1.19.tar.bz2 \
     && cd bcftools-1.19/ && ./configure --prefix=/usr/local/bin/ && make && make install && export PATH=/usr/local/bin/bin:$PATH && cd .. && cp /usr/local/bin/bin/* /usr/local/bin/
 
-RUN bcftools
-
 RUN git clone --recursive https://github.com/waveygang/wfmash \
     && cd wfmash \
     && git pull \

--- a/Dockerfile
+++ b/Dockerfile
@@ -180,7 +180,7 @@ RUN wget https://github.com/arq5x/bedtools2/releases/download/v2.31.0/bedtools.s
 # current bcftools
 RUN wget https://github.com/samtools/bcftools/releases/download/1.19/bcftools-1.19.tar.bz2 \
     && tar xjf bcftools-1.19.tar.bz2 \
-    && cd bcftools-1.19/ && ./configure --prefix=/usr/local/bin/ && make && make install && export PATH=/usr/local/bin/bin:$PATH && cd ..
+    && cd bcftools-1.19/ && ./configure --prefix=/usr/local/bin/ && make && make install && export PATH=/usr/local/bin/bin:$PATH && cd .. && cp /usr/local/bin/bin/* /usr/local/bin/
 
 RUN bcftools
 


### PR DESCRIPTION
Bumping bcftools to v1.19 fixes errors like

```
   corrupted size vs. prev_size
   .command.sh: line 28: 1163333 Aborted (core dumped) bcftools stats $vcf_decomposed > $vcf_decomposed.stats
```

