### PR TITLE
only fail if non-installed programs are required

### DIFF
--- a/partition-before-pggb
+++ b/partition-before-pggb
@@ -276,11 +276,15 @@ check_tool_availability "seqwish" "seqwish"
 check_tool_availability "smoothxg" "smoothxg"
 check_tool_availability "odgi" "odgi"
 check_tool_availability "gfaffix" "gfaffix"
+if [ "$vcf_spec" != "false" ]; then
 check_tool_availability "vg" "vg"
 check_tool_availability "vcfbub" "vcfbub"
 check_tool_availability "vcfwave" "vcfwave"
 check_tool_availability "bcftools" "bcftools"
+fi
+if [[ $multiqc == true ]]; then
 check_tool_availability "MultiQC" "multiqc"
+fi
 
 # If there are missing tools, report them and exit
 if [ ${#missing_tools[@]} -ne 0 ]; then

--- a/pggb
+++ b/pggb
@@ -276,11 +276,15 @@ check_tool_availability "seqwish" "seqwish"
 check_tool_availability "smoothxg" "smoothxg"
 check_tool_availability "odgi" "odgi"
 check_tool_availability "gfaffix" "gfaffix"
+if [ "$vcf_spec" != "false" ]; then
 check_tool_availability "vg" "vg"
 check_tool_availability "vcfbub" "vcfbub"
 check_tool_availability "vcfwave" "vcfwave"
 check_tool_availability "bcftools" "bcftools"
+fi
+if [[ $multiqc == true ]]; then
 check_tool_availability "MultiQC" "multiqc"
+fi
 
 # If there are missing tools, report them and exit
 if [ ${#missing_tools[@]} -ne 0 ]; then


### PR DESCRIPTION
I (probably at my own peril) never use multiqc or deconstruct variants within my graph building pipelines, so don't have these tools installed. pggb runs fine without them, so hopefully this guards against errors when users do want those analyses but don't have the tools installed, but still leaves flexibility for others.

On a related note, I have wfmash etc compiled for our compute nodes which gives "illegal instruction" errors on our head nodes due to different architectures. The `command -v wfmash` returns happily saying it is installed but then the program just exits silently, not even creating the output directory. Something like `wfmash --version` catches this, but not all tools have that hook (like vcfwave), so this is probably a user problem rather than something pggb should handle gracefully.