### PR TITLE
Add pggb version to its own log

### DIFF
--- a/partition-before-pggb
+++ b/partition-before-pggb
@@ -171,10 +171,10 @@ while true ; do
     esac
 done
 
+SCRIPT_DIR=$( cd -- "$(dirname -- "$(readlink -f "${BASH_SOURCE[0]}" )" )" &> /dev/null && pwd )
+GIT_VERSION=$( cd "$SCRIPT_DIR"; git describe --always --tags --long )
+
 if [ "$show_version" == true ]; then
-    SCRIPT_DIR=$( cd -- "$(dirname -- "$(readlink -f "${BASH_SOURCE[0]}" )" )" &> /dev/null && pwd )
-    cd "$SCRIPT_DIR"
-    GIT_VERSION=$(git describe --always --tags --long)
     echo "pggb $GIT_VERSION"
     cd - &> /dev/null
     exit
@@ -495,6 +495,8 @@ general:
   compress:           $compress
   threads:            $threads
   poa_threads:        $poa_threads
+pggb:
+  version:            $GIT_VERSION
 $mapper:
   version:            $mapper_version
   segment-length:     $segment_length

--- a/pggb
+++ b/pggb
@@ -171,10 +171,10 @@ while true ; do
     esac
 done
 
+SCRIPT_DIR=$( cd -- "$(dirname -- "$(readlink -f "${BASH_SOURCE[0]}" )" )" &> /dev/null && pwd )
+GIT_VERSION=$( cd "$SCRIPT_DIR"; git describe --always --tags --long )
+
 if [ "$show_version" == true ]; then
-    SCRIPT_DIR=$( cd -- "$(dirname -- "$(readlink -f "${BASH_SOURCE[0]}" )" )" &> /dev/null && pwd )
-    cd "$SCRIPT_DIR"
-    GIT_VERSION=$(git describe --always --tags --long)
     echo "pggb $GIT_VERSION"
     cd - &> /dev/null
     exit
@@ -495,6 +495,8 @@ general:
   compress:           $compress
   threads:            $threads
   poa_threads:        $poa_threads
+pggb:
+  version:            $GIT_VERSION
 $mapper:
   version:            $mapper_version
   segment-length:     $segment_length


### PR DESCRIPTION
There is no record of what pggb version was used in the log files, which is probably useful information to check in case tool are out of sync.

On a side note, the `pggb --version` command only seems to work if you have the git version rather than a release tar. That gives an error like
```
fatal: Not a valid object name HEAD
```

Maybe there should be a release-pinned version as a variable to fall back on if the git version is not defined.