### PR TITLE
Correctly pass POA params to smoothxg

### DIFF
--- a/pggb
+++ b/pggb
@@ -425,18 +425,18 @@ fi
 # between asm10 and asm20 ~ 1,7,11,2,33,1
 poa_params_cmd=""
 if [[ $poa_params == false ]]; then
-    poa_params_cmd="-P 1,19,39,3,81,1"
+    poa_params_cmd="-p 1,19,39,3,81,1"
 else
     if [[ $poa_params == "asm5" ]]; then
-        poa_params_cmd="-P 1,19,39,3,81,1"
+        poa_params_cmd="-p 1,19,39,3,81,1"
     elif [[ $poa_params == "asm10" ]]; then
-        poa_params_cmd="-P 1,9,16,2,41,1"
+        poa_params_cmd="-p 1,9,16,2,41,1"
     elif [[ $poa_params == "asm15" ]]; then
-        poa_params_cmd="-P 1,7,11,2,33,1"
+        poa_params_cmd="-p 1,7,11,2,33,1"
     elif [[ $poa_params == "asm20" ]]; then
-        poa_params_cmd="-P 1,4,6,2,26,1"
+        poa_params_cmd="-p 1,4,6,2,26,1"
     else
-        poa_params_cmd="-P $poa_params"
+        poa_params_cmd="-p $poa_params"
     fi
 fi
 


### PR DESCRIPTION
Hopefully not missing something obvious, but you set the POA params in `pggb` via `-P` or `--poa-params`. This was passed on in the $poa_params_cmd variable to `smoothxg` as e.g. `poa_params_cmd="-P 1,19,39,3,81,1"`. However, `smoothxg` takes `-p` (lowercase) or `--poa-params`, and `-P` is instead the short arg for `--ref-paths`. As far as I can tell, consensus reference paths are ignored (commented out [here](https://github.com/pangenome/smoothxg/blob/e93c62356b33c2f6db727452328e09a33bfc82c6/src/main.cpp#L1071C13-L1071C23)), so maybe why this was not causing an error.

This might also explain what @baozg reported in #320, since `-P` is effectively a dead parameter and the default POA params get used anyway.