### PR TITLE
Fix #479: partition-before-pggb emits -p instead of -P for poa-params

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,7 @@ RUN git clone https://github.com/pangenome/vcfbub \
     && cd vcfbub \
     && git pull \
     && git checkout 77289654b246a4e3422902d04277e258d9fabe9a \
-    && cargo install --force --path . \
+    && cargo install --force --locked --path . \
     && mv /root/.cargo/bin/vcfbub /usr/local/bin/vcfbub \
     && cd ../ \
     && rm -rf vcfbub
@@ -133,7 +133,7 @@ RUN git clone https://github.com/ekg/fastix.git \
     && cd fastix \
     && git pull \
     && git checkout 331c1159ea16625ee79d1a82522e800c99206834 \
-    && cargo install --force --path . && \
+    && cargo install --force --locked --path . && \
     mv /root/.cargo/bin/fastix /usr/local/bin/fastix \
     && cd ../ \
     && rm -rf fastix
@@ -143,7 +143,7 @@ RUN PORTABLE=1 git clone --recursive https://github.com/pangenome/impg.git \
     && git pull \
     && git checkout f773342a75da244f05bc93663857b77c3bc8a9f7 \
     && git submodule update --init --recursive \
-    && PORTABLE=1 cargo install --force --path . \
+    && PORTABLE=1 cargo install --force --locked --path . \
     && mv /root/.cargo/bin/impg /usr/local/bin/impg \
     && cd ../ \
     && rm -rf impg
@@ -152,7 +152,7 @@ RUN git clone https://github.com/pangenome/gfalook.git \
     && cd gfalook \
     && git pull \
     && git checkout 5199d77ecc4980b181177c16b94f6e56c0d06e4c \
-    && cargo install --force --path . \
+    && cargo install --force --locked --path . \
     && mv /root/.cargo/bin/gfalook /usr/local/bin/gfalook \
     && cd ../ \
     && rm -rf gfalook
@@ -161,7 +161,7 @@ RUN git clone https://github.com/ekg/pafplot.git \
     && cd pafplot \
     && git pull \
     && git checkout 2785b0ef30d37300afc77fd4b04d1d949c143551 \
-    && cargo install --force --path . \
+    && cargo install --force --locked --path . \
     && mv /root/.cargo/bin/pafplot /usr/local/bin/ \
     && cd ../ \
     && rm -rf pafplot

--- a/partition-before-pggb
+++ b/partition-before-pggb
@@ -425,18 +425,18 @@ fi
 # between asm10 and asm20 ~ 1,7,11,2,33,1
 poa_params_cmd=""
 if [[ $poa_params == false ]]; then
-    poa_params_cmd="-p 1,4,6,2,26,1" # asm20 by default
+    poa_params_cmd="-P 1,4,6,2,26,1" # asm20 by default
 else
     if [[ $poa_params == "asm5" ]]; then
-        poa_params_cmd="-p 1,19,39,3,81,1"
+        poa_params_cmd="-P 1,19,39,3,81,1"
     elif [[ $poa_params == "asm10" ]]; then
-        poa_params_cmd="-p 1,9,16,2,41,1"
+        poa_params_cmd="-P 1,9,16,2,41,1"
     elif [[ $poa_params == "asm15" ]]; then
-        poa_params_cmd="-p 1,7,11,2,33,1"
+        poa_params_cmd="-P 1,7,11,2,33,1"
     elif [[ $poa_params == "asm20" ]]; then
-        poa_params_cmd="-p 1,4,6,2,26,1"
+        poa_params_cmd="-P 1,4,6,2,26,1"
     else
-        poa_params_cmd="-p $poa_params"
+        poa_params_cmd="-P $poa_params"
     fi
 fi
 


### PR DESCRIPTION
`poa_params_cmd` in `partition-before-pggb` used `-p`, but it is spliced into a generated `pggb` command where `-p`=map-pct-id and `-P`=poa-params. That line already passes `-p $map_pct_id`, so the extra `-p` clobbered it and crashed wfmash (`Argument '%' received invalid value type '1,4,6,2,26,1'`). Changed to `-P`.

pggb's own copy stays `-p` (there it feeds smoothxg, whose `-p` is poa-params).

Fixes #479
