### PR TITLE
Fix #356: reject commas in output/temp dir paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,7 @@ RUN git clone https://github.com/pangenome/vcfbub \
     && cd vcfbub \
     && git pull \
     && git checkout 77289654b246a4e3422902d04277e258d9fabe9a \
-    && cargo install --force --path . \
+    && cargo install --force --locked --path . \
     && mv /root/.cargo/bin/vcfbub /usr/local/bin/vcfbub \
     && cd ../ \
     && rm -rf vcfbub
@@ -133,7 +133,7 @@ RUN git clone https://github.com/ekg/fastix.git \
     && cd fastix \
     && git pull \
     && git checkout 331c1159ea16625ee79d1a82522e800c99206834 \
-    && cargo install --force --path . && \
+    && cargo install --force --locked --path . && \
     mv /root/.cargo/bin/fastix /usr/local/bin/fastix \
     && cd ../ \
     && rm -rf fastix
@@ -143,7 +143,7 @@ RUN PORTABLE=1 git clone --recursive https://github.com/pangenome/impg.git \
     && git pull \
     && git checkout f773342a75da244f05bc93663857b77c3bc8a9f7 \
     && git submodule update --init --recursive \
-    && PORTABLE=1 cargo install --force --path . \
+    && PORTABLE=1 cargo install --force --locked --path . \
     && mv /root/.cargo/bin/impg /usr/local/bin/impg \
     && cd ../ \
     && rm -rf impg
@@ -152,7 +152,7 @@ RUN git clone https://github.com/pangenome/gfalook.git \
     && cd gfalook \
     && git pull \
     && git checkout 5199d77ecc4980b181177c16b94f6e56c0d06e4c \
-    && cargo install --force --path . \
+    && cargo install --force --locked --path . \
     && mv /root/.cargo/bin/gfalook /usr/local/bin/gfalook \
     && cd ../ \
     && rm -rf gfalook
@@ -161,7 +161,7 @@ RUN git clone https://github.com/ekg/pafplot.git \
     && cd pafplot \
     && git pull \
     && git checkout 2785b0ef30d37300afc77fd4b04d1d949c143551 \
-    && cargo install --force --path . \
+    && cargo install --force --locked --path . \
     && mv /root/.cargo/bin/pafplot /usr/local/bin/ \
     && cd ../ \
     && rm -rf pafplot

--- a/partition-before-pggb
+++ b/partition-before-pggb
@@ -306,6 +306,16 @@ elif [ "$n_mappings" -lt 1 ]; then
     exit
 fi
 
+# seqwish interprets commas as PAF-file separators, so paths reaching it must not contain commas
+if [[ "$output_dir" == *,* ]]; then
+    >&2 echo "[pggb] ERROR: -o/--output-dir cannot contain commas (','): seqwish interprets them as PAF-file separators."
+    exit 1
+fi
+if [[ "$input_temp_dir" != false && "$input_temp_dir" == *,* ]]; then
+    >&2 echo "[pggb] ERROR: -D/--temp-dir cannot contain commas (','): seqwish interprets them as PAF-file separators."
+    exit 1
+fi
+
 # Check Pangenome Sequence Naming (PanSN)
 pansn_not_respected=false
 while IFS= read -r line; do

--- a/pggb
+++ b/pggb
@@ -306,6 +306,16 @@ elif [ "$n_mappings" -lt 1 ]; then
     exit
 fi
 
+# seqwish interprets commas as PAF-file separators, so paths reaching it must not contain commas
+if [[ "$output_dir" == *,* ]]; then
+    >&2 echo "[pggb] ERROR: -o/--output-dir cannot contain commas (','): seqwish interprets them as PAF-file separators."
+    exit 1
+fi
+if [[ "$input_temp_dir" != false && "$input_temp_dir" == *,* ]]; then
+    >&2 echo "[pggb] ERROR: -D/--temp-dir cannot contain commas (','): seqwish interprets them as PAF-file separators."
+    exit 1
+fi
+
 # Check Pangenome Sequence Naming (PanSN)
 pansn_not_respected=false
 while IFS= read -r line; do


### PR DESCRIPTION
seqwish reads commas in a PAF path as a file-list separator, so `-o pggb_..._G700,1000` made it look for nonexistent PAFs and abort. `pggb` and `partition-before-pggb` now reject a comma in `-o`/`-D` up front with a clear error. No-comma runs unaffected.

Fixes #356
