### PR TITLE
Fix #399: -V reference prefix collides across samples (chm1 vs chm13)

### DIFF
--- a/pggb
+++ b/pggb
@@ -768,10 +768,14 @@ if [[ $vcf_spec != false ]]; then
         if [[ -z $pop_length ]]; then
           pop_length=0
         fi
+        # vg deconstruct -P is a plain prefix match, so append the PanSN '#' delimiter to
+        # the reference to match whole samples/haplotypes (e.g. 'chm1' must not also match 'chm13')
+        ref_prefix="$ref"
+        [[ "$ref_prefix" != *'#' ]] && ref_prefix="$ref_prefix#"
         vcf="$prefix_smoothed_output".final.$(echo $ref | tr '/|' '_').vcf
         if [[ ! -s $vcf || $resume == false ]]; then
           echo "[vg::deconstruct] making VCF with reference=$ref and delim=# xxxxxxxxxxxxx $s ------------ $pop_length"
-          ( TEMPDIR=$(pwd) $timer -f "$fmt" vg deconstruct -P "$ref" \
+          ( TEMPDIR=$(pwd) $timer -f "$fmt" vg deconstruct -P "$ref_prefix" \
                    -H "#" -e -a -t $threads "$prefix_smoothed_output".final.gfa >"$vcf" ) 2> >(tee -a "$log_file")
           bcftools stats "$vcf" > "$vcf".stats
         fi


### PR DESCRIPTION
`vg deconstruct -P` is a plain prefix match, so `-V 'chm1'` also matched `chm13` (silently dropping chm13 as a sample), and haplotype-level refs like `ind1#1` couldn't be selected. Append the PanSN `#` delimiter to the `-P` argument.

Reproduced on LPA (has both `chm1` and `chm13`): buggy `-V 'chm1'` gave 1467 variants with chm13 absent from samples; fixed gives 1183 with chm13 a sample. Haplotype-level `-V 'HG002#1'` now works. VCF filenames unchanged.

Fixes #399
