### PR TITLE
Fix #297: gfa2evaluation.sh moves the input GFA into the output dir

### DIFF
--- a/scripts/gfa2evaluation.sh
+++ b/scripts/gfa2evaluation.sh
@@ -220,5 +220,10 @@ mkdir -p "$DIR_OUTPUT"
 rm -rf "$DIR_OUTPUT"/*.sdf
 rm -rf "$DIR_OUTPUT"/nucmer
 rm -rf "$DIR_OUTPUT"/vcfeval
-mv "$PREFIX"* statistics.haplo*.tsv nucmer vcfeval "$DIR_OUTPUT"
+# never move the input GFA: it can match "$PREFIX"* when it is in the working directory (issue #297)
+for f in "$PREFIX"*; do
+    [[ "$(readlink -f "$f")" == "$(readlink -f "$PATH_GFA")" ]] && continue
+    mv "$f" "$DIR_OUTPUT"
+done
+mv statistics.haplo*.tsv nucmer vcfeval "$DIR_OUTPUT"
 


### PR DESCRIPTION
`PREFIX` is the input GFA basename, so the final `mv "$PREFIX"* ... "$DIR_OUTPUT"` also moved the input GFA when it was in the working directory, so the run couldn't be repeated. Skip the input path when moving outputs.

Reproduced with `chrM.pan.4.gfa` (`PREFIX=chrM.pan.4`): the input got moved into the output dir; after the fix it stays put and only generated outputs move.

Fixes #297
