### PR TITLE
Accept AGC archives as input

### DIFF
--- a/.github/workflows/build_and_test_docker.yml
+++ b/.github/workflows/build_and_test_docker.yml
@@ -18,7 +18,7 @@ jobs:
           # This reproduces the "Illegal instruction" crash seen on Apple Silicon Macs
           # running x86_64 Docker images under QEMU emulation.
           failed=0
-          for bin in wfmash seqwish smoothxg; do
+          for bin in wfmash seqwish smoothxg agc; do
             echo "==> Testing $bin for AVX portability..."
             docker run -v /usr/bin/qemu-x86_64-static:/usr/bin/qemu-x86_64-static pggb \
               bash -c "qemu-x86_64-static -cpu Westmere /usr/local/bin/$bin --version 2>&1; ret=\$?; if [ \$ret -eq 132 ]; then echo 'FATAL: $bin crashed with Illegal instruction (AVX?)'; exit 1; fi; exit 0" || failed=1
@@ -39,5 +39,22 @@ jobs:
         run: docker run -v ${PWD}/data/:/data pggb /bin/bash -c "pggb -i data/HLA/DRB1-3123.fa.gz -a data/paf/DRB1-3123.fa.15a1009.wfmash.paf -G 2000 -n 10 -t 2 -Z -M -m -o drib1_paf && ls drib1_paf/* && head drib1_paf/*.log -n 63"
       - name: Run a test on the LPA dataset (SPOA global)
         run: docker run -v ${PWD}/data/:/data pggb /bin/bash -c "pggb -i data/LPA/LPA.fa.gz -p 95 -s 2000 -G 800,900 -k 79 -t 2 -Z -O 0.001 -m --global-poa -o lpa -V 'chm13,chm1:1000' && ls lpa/* && head lpa/*.log -n 63"
+      - name: Run a test on the DRB1-3123 dataset stored in an AGC archive
+        run: |
+          docker run -v ${PWD}/data/:/data pggb /bin/bash -c '
+            set -eux
+            cd /tmp
+            # build an AGC archive from the same sequences the FASTA test uses
+            zcat /data/HLA/DRB1-3123.fa.gz > drb1.fa
+            samtools faidx drb1.fa
+            agc create -o drb1.agc drb1.fa
+            # induce the graph from both, reusing one alignment so the only difference
+            # is where the sequences come from (-A keeps the seqwish graph)
+            paf=/data/paf/DRB1-3123.fa.15a1009.wfmash.paf
+            pggb -i drb1.fa  -a "$paf" -n 12 -t 2 -A -o out_fasta
+            pggb -i drb1.agc -a "$paf" -n 12 -t 2 -A -o out_agc
+            diff out_fasta/*.seqwish.gfa out_agc/*.seqwish.gfa
+            echo "AGC input produced the same graph as the FASTA"
+          '
       - name: Run a test for the gfa2evaluation script on a mini HPRC chrMT dataset
         run: docker run -v ${PWD}/data/:/data pggb /bin/bash -c "gfa2evaluation.sh data/chrM.pan.4.gfa chm13 data/test_eval 2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,11 +101,13 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN cargo --help
 
-# seqwish is a Rust crate, so it is built after the Rust toolchain is available
+# seqwish is a Rust crate, so it is built after the Rust toolchain is available.
+# RUSTFLAGS overrides the target-cpu=native in the crate's .cargo/config.toml, which would
+# otherwise bake the build machine's instruction set (AVX) into the image.
 RUN git clone https://github.com/pangenome/seqwish \
     && cd seqwish \
     && git checkout aab5beeb8d734134dfb7cc0c44fc5a38cb580a4b \
-    && cargo install --force --locked --path . \
+    && RUSTFLAGS="-C target-cpu=x86-64-v2" cargo install --force --locked --path . \
     && mv /root/.cargo/bin/seqwish /usr/local/bin/seqwish \
     && cd ../ \
     && rm -rf seqwish

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,13 +52,28 @@ RUN wget https://github.com/samtools/bcftools/releases/download/1.19/bcftools-1.
     && tar xjf bcftools-1.19.tar.bz2 \
     && cd bcftools-1.19/ && ./configure --prefix=/usr/local/bin/ && make && make install && export PATH=/usr/local/bin/bin:$PATH && cd .. && cp /usr/local/bin/bin/* /usr/local/bin/
 
+# AGC (Assembled Genomes Compressor): the agc binary lets pggb list and extract the sequences
+# of an .agc input, and libagc is linked into wfmash so it can read archives directly.
+# PLATFORM=sse2 keeps the build portable (AGC defaults to -march=native).
+# Only the few files wfmash links against are kept, the source tree is dropped.
+RUN git clone --recursive --branch v3.2.1 https://github.com/refresh-bio/agc /opt/agc-src \
+    && cd /opt/agc-src \
+    && make PLATFORM=sse2 -j $(nproc) \
+    && cp bin/agc /usr/local/bin/agc \
+    && mkdir -p /opt/agc/bin /opt/agc/src/lib-cxx /opt/agc/3rd_party/zstd/lib \
+    && cp bin/libagc.a /opt/agc/bin/ \
+    && cp src/lib-cxx/agc-api.h /opt/agc/src/lib-cxx/ \
+    && cp 3rd_party/zstd/lib/libzstd.a /opt/agc/3rd_party/zstd/lib/ \
+    && cd / \
+    && rm -rf /opt/agc-src
+
 RUN git clone --recursive https://github.com/waveygang/wfmash \
     && cd wfmash \
     && git pull \
     && git checkout v0.14.1 \
     && git submodule update --init --recursive \
     && find . \( -name CMakeLists.txt -o -name Makefile \) -exec sed -i 's/-march=native/-march=x86-64-v2/g' {} + \
-    && cmake -H. -DCMAKE_BUILD_TYPE=Generic -DEXTRA_FLAGS='-march=x86-64-v2 -Ofast' -Bbuild && cmake --build build -- -j $(nproc) \
+    && cmake -H. -DCMAKE_BUILD_TYPE=Generic -DEXTRA_FLAGS='-march=x86-64-v2 -Ofast' -DAGC_ROOT=/opt/agc -Bbuild && cmake --build build -- -j $(nproc) \
     && cp build/bin/wfmash /usr/local/bin/wfmash \
     # Libraries aren't getting installed
     && cp build/lib/* /usr/local/lib/ \
@@ -67,17 +82,6 @@ RUN git clone --recursive https://github.com/waveygang/wfmash \
     && sed -i 's/kill 1, \$child;/kill 1, \$child if \$child > 1;/' /usr/local/bin/paf2dotplot \
     && cd ../ \
     && rm -rf wfmash
-
-RUN git clone --recursive https://github.com/ekg/seqwish \
-    && cd seqwish \
-    && git pull \
-    && git checkout 90dc76e1204fcfc6d9642373cb05dca8aa197164 \
-    && git submodule update --init --recursive \
-    && find . \( -name CMakeLists.txt -o -name Makefile \) -exec sed -i 's/-march=native/-march=x86-64-v2/g' {} + \
-    && cmake -H. -DCMAKE_BUILD_TYPE=Generic -DEXTRA_FLAGS='-march=x86-64-v2 -Ofast' -Bbuild && cmake --build build -- -j $(nproc) \
-    && cp bin/seqwish /usr/local/bin/seqwish \
-    && cd ../ \
-    && rm -rf seqwish
 
 RUN git clone --recursive https://github.com/pangenome/smoothxg \
     && cd smoothxg \
@@ -96,6 +100,15 @@ RUN git clone --recursive https://github.com/pangenome/smoothxg \
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN cargo --help
+
+# seqwish is a Rust crate, so it is built after the Rust toolchain is available
+RUN git clone https://github.com/pangenome/seqwish \
+    && cd seqwish \
+    && git checkout aab5beeb8d734134dfb7cc0c44fc5a38cb580a4b \
+    && cargo install --force --locked --path . \
+    && mv /root/.cargo/bin/seqwish /usr/local/bin/seqwish \
+    && cd ../ \
+    && rm -rf seqwish
 
 RUN git clone https://github.com/marschall-lab/GFAffix.git \
     && cd GFAffix \

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ also rectifies issues with the initial wfa-based alignment.
 
 You'll need `wfmash`, `seqwish`, `smoothxg`, `odgi`, and `gfaffix` in your shell's `PATH`.
 These can be individually built and installed.
+To use an AGC archive (`.agc`) as input you also need [`agc`](https://github.com/refresh-bio/agc) in your `PATH`, and a `wfmash` built with AGC support.
 Then, put the `pggb` bash script in your path to complete installation.
 Optionally, install `bcftools`, `vcfbub`, `vcfwave`, and `vg` for calling and normalizing variants, `MultiQC` for generating summarized statistics in a MultiQC report, or `pigz` to compress the output files of the pipeline.
 

--- a/docs/rst/installation.rst
+++ b/docs/rst/installation.rst
@@ -12,7 +12,7 @@ Manual-mode
    <br />
 
 You'll need `wfmash <https://github.com/waveygang/wfmash>`_, `seqwish <https://github.com/ekg/seqwish>`_, `smoothxg <https://github.com/pangenome/smoothxg>`_,
-`odgi <https://github.com/pangenome/odgi>`_, and `gfaffix <https://github.com/marschall-lab/GFAffix>`_ in your shell's ``PATH``. They can be build from source or installed via Bioconda. Then, add the ``pggb`` bash script to your ``PATH`` to complete the installation. 
+`odgi <https://github.com/pangenome/odgi>`_, and `gfaffix <https://github.com/marschall-lab/GFAffix>`_ in your shell's ``PATH``. They can be build from source or installed via Bioconda. To use an AGC archive (``.agc``) as input, you also need `agc <https://github.com/refresh-bio/agc>`_ in your ``PATH`` and a ``wfmash`` built with AGC support. Then, add the ``pggb`` bash script to your ``PATH`` to complete the installation.
 `How to add a binary to my path? <https://zwbetz.com/how-to-add-a-binary-to-your-path-on-macos-linux-windows/>`_ |br|
 Optionally, install `bcftools <https://github.com/samtools/bcftools>`_, `vcfbub <https://github.com/pangenome/vcfbub>`_, `vcfwave <https://github.com/vcflib/vcflib>`, and `vg <https://github.com/vgteam/vg>`_ for calling and normalizing variants, `MultiQC <https://multiqc.info/>`_ for generating summarized statistics in a MultiQC report, or `pigz <https://zlib.net/pigz/>`_ to compress the output files of the pipeline.
 

--- a/partition-before-pggb
+++ b/partition-before-pggb
@@ -187,7 +187,7 @@ if [ "$show_help" == true ]; then
     echo "usage: $0 -i <input-fasta> -o <output-dir> [options]"
     echo "options:"
     echo "   [wfmash]"
-    echo "    -i, --input-fasta FILE      input FASTA/FASTQ file"
+    echo "    -i, --input-fasta FILE      input FASTA/FASTQ file, or an AGC archive (.agc)"
     echo "    -s, --segment-length N      segment length for mapping [default: "$SEGMENT_LENGTH"]"
     echo "    -l, --block-length N        minimum block length filter for mapping [default: 5*segment-length]"
     echo "    -p, --map-pct-id PCT        percent identity for mapping/alignment [default: "$MAP_PCT_ID"]"
@@ -286,6 +286,13 @@ if [[ $multiqc == true ]]; then
 check_tool_availability "MultiQC" "multiqc"
 fi
 
+# AGC input support: an .agc archive is enumerated/extracted with the agc CLI instead of a samtools .fai
+input_is_agc=false
+if [[ "$input_fasta" == *.agc ]]; then
+    input_is_agc=true
+    check_tool_availability "agc" "agc"
+fi
+
 # If there are missing tools, report them and exit
 if [ ${#missing_tools[@]} -ne 0 ]; then
   echo "[pggb] ERROR: the following tools are not installed or not in the PATH:"
@@ -295,10 +302,31 @@ if [ ${#missing_tools[@]} -ne 0 ]; then
   exit 1
 fi
 
+# Emit one sequence name per line: from the samtools .fai for FASTA/FASTQ, or from
+# the AGC archive (listctg lists contigs indented under each sample name) for .agc.
+pggb_seq_names() {
+    if [[ "$input_is_agc" == true ]]; then
+        agc listctg "$input_fasta" $(agc listset "$input_fasta") | grep '^ ' | awk '{print $1}'
+    else
+        cut -f 1 "${input_fasta}.fai"
+    fi
+}
+
+# Command (as an array, so $timer can wrap it) that extracts the named sequences of a
+# community to FASTA on stdout: samtools faidx for FASTA/FASTQ, agc getctg for .agc.
+if [[ "$input_is_agc" == true ]]; then
+    extract_cmd=(agc getctg "$input_fasta")
+else
+    extract_cmd=(samtools faidx "$input_fasta")
+fi
+
 if [ "$input_fasta" = "false" ] || [ "$output_dir" = "false" ]; then
     >&2 echo "[pggb] ERROR: mandatory argument: -i/--input-fasta and -o/--output-dir"
     exit
-elif [ ! -f "${input_fasta}.fai" ]; then
+elif [[ "$input_is_agc" == true && ! -f "$input_fasta" ]]; then
+    echo "[pggb] ERROR: input AGC archive $input_fasta does not exist."
+    exit 1
+elif [[ "$input_is_agc" == false && ! -f "${input_fasta}.fai" ]]; then
     echo "[pggb] ERROR: index for $input_fasta does not exist. Please create it using 'samtools faidx $input_fasta'."
     exit 1
 elif [ "$n_mappings" -lt 1 ]; then
@@ -316,6 +344,19 @@ if [[ "$input_temp_dir" != false && "$input_temp_dir" == *,* ]]; then
     exit 1
 fi
 
+# AGC identifies a sequence by (sample, contig), so an archive may hold the same contig name
+# in several samples. pggb needs every sequence to have a unique name (PanSN gives one by
+# construction), and `agc getctg` writes the bare contig name as the FASTA header, so such an
+# archive cannot be extracted unambiguously. Reject it rather than build a corrupt graph.
+if [[ "$input_is_agc" == true ]]; then
+  duplicated_name=$(pggb_seq_names | sort | uniq -d | head -n 1)
+  if [[ -n "$duplicated_name" ]]; then
+    >&2 echo "[pggb] ERROR: $input_fasta contains the contig name '$duplicated_name' in more than one sample."
+    >&2 echo "[pggb] Sequence names must be unique; use Pangenome Sequence Naming (sample#haplotype#contig)."
+    exit 1
+  fi
+fi
+
 # Check Pangenome Sequence Naming (PanSN)
 pansn_not_respected=false
 while IFS= read -r line; do
@@ -323,7 +364,7 @@ while IFS= read -r line; do
     pansn_not_respected=$line
     break
   fi
-done < <(cut -f 1 "${input_fasta}.fai")
+done < <(pggb_seq_names)
 if [ "$pansn_not_respected" != "false" ]; then
   >&2 echo "[pggb] warning: there are sequence names (like '$pansn_not_respected') that do not match the Pangenome Sequence Naming (PanSN)."
   
@@ -381,7 +422,7 @@ fi
 
 # Normalization ($n_haps is checked in this part of the script because it is also used for the 'auto' mapping sparsification)
 if [[ $n_haps == false ]]; then
-    n_haps=$(cut -f 1 "${input_fasta}.fai" | cut -f 1,2 -d '#' | sort | uniq | wc -l)
+    n_haps=$(pggb_seq_names | cut -f 1,2 -d '#' | sort | uniq | wc -l)
 fi
 
 sparse_map_cmd=""
@@ -606,13 +647,13 @@ ls "$prefix_paf".community.*.txt | while read community; do
   prefix_fasta="$output_dir"/$(basename "$community" .txt)
   if [[ $compress == true ]]; then
     if [[ ! -s "$prefix_fasta".fa.gz || $resume == false ]]; then
-      ($timer -f "$fmt" samtools faidx "$input_fasta" $(cat "$community") | \
+      ($timer -f "$fmt" "${extract_cmd[@]}" $(cat "$community") | \
         bgzip -@ "$threads" -c > "$prefix_fasta".fa.gz) 2> >(tee -a "$log_file")
       ($timer -f "$fmt" samtools faidx "$prefix_fasta".fa.gz) 2> >(tee -a "$log_file")
     fi
   else
     if [[ ! -s "$prefix_fasta".fa || $resume == false ]]; then
-      ($timer -f "$fmt" samtools faidx "$input_fasta" $(cat "$community") \
+      ($timer -f "$fmt" "${extract_cmd[@]}" $(cat "$community") \
         > "$prefix_fasta".fa) 2> >(tee -a "$log_file")
       ($timer -f "$fmt" samtools faidx "$prefix_fasta".fa) 2> >(tee -a "$log_file")
     fi

--- a/pggb
+++ b/pggb
@@ -187,7 +187,7 @@ if [ "$show_help" == true ]; then
     echo "usage: $0 -i <input-fasta> -o <output-dir> [options]"
     echo "options:"
     echo "   [wfmash]"
-    echo "    -i, --input-fasta FILE      input FASTA/FASTQ file"
+    echo "    -i, --input-fasta FILE      input FASTA/FASTQ file, or an AGC archive (.agc)"
     echo "    -s, --segment-length N      segment length for mapping [default: "$SEGMENT_LENGTH"]"
     echo "    -l, --block-length N        minimum block length filter for mapping [default: 5*segment-length]"
     echo "    -p, --map-pct-id PCT        percent identity for mapping/alignment [default: "$MAP_PCT_ID"]"
@@ -286,6 +286,13 @@ if [[ $multiqc == true ]]; then
 check_tool_availability "MultiQC" "multiqc"
 fi
 
+# AGC input support: an .agc archive is enumerated with the agc CLI instead of a samtools .fai
+input_is_agc=false
+if [[ "$input_fasta" == *.agc ]]; then
+    input_is_agc=true
+    check_tool_availability "agc" "agc"
+fi
+
 # If there are missing tools, report them and exit
 if [ ${#missing_tools[@]} -ne 0 ]; then
   echo "[pggb] ERROR: the following tools are not installed or not in the PATH:"
@@ -295,10 +302,23 @@ if [ ${#missing_tools[@]} -ne 0 ]; then
   exit 1
 fi
 
+# Emit one sequence name per line: from the samtools .fai for FASTA/FASTQ, or from
+# the AGC archive (listctg lists contigs indented under each sample name) for .agc.
+pggb_seq_names() {
+    if [[ "$input_is_agc" == true ]]; then
+        agc listctg "$input_fasta" $(agc listset "$input_fasta") | grep '^ ' | awk '{print $1}'
+    else
+        cut -f 1 "${input_fasta}.fai"
+    fi
+}
+
 if [ "$input_fasta" = "false" ] || [ "$output_dir" = "false" ]; then
     >&2 echo "[pggb] ERROR: mandatory argument: -i/--input-fasta and -o/--output-dir"
     exit
-elif [ ! -f "${input_fasta}.fai" ]; then
+elif [[ "$input_is_agc" == true && ! -f "$input_fasta" ]]; then
+    echo "[pggb] ERROR: input AGC archive $input_fasta does not exist."
+    exit 1
+elif [[ "$input_is_agc" == false && ! -f "${input_fasta}.fai" ]]; then
     echo "[pggb] ERROR: index for $input_fasta does not exist. Please create it using 'samtools faidx $input_fasta'."
     exit 1
 elif [ "$n_mappings" -lt 1 ]; then
@@ -316,6 +336,19 @@ if [[ "$input_temp_dir" != false && "$input_temp_dir" == *,* ]]; then
     exit 1
 fi
 
+# AGC identifies a sequence by (sample, contig), so an archive may hold the same contig name
+# in several samples. pggb needs every sequence to have a unique name (PanSN gives one by
+# construction), and `agc getctg` writes the bare contig name as the FASTA header, so such an
+# archive cannot be extracted unambiguously. Reject it rather than build a corrupt graph.
+if [[ "$input_is_agc" == true ]]; then
+  duplicated_name=$(pggb_seq_names | sort | uniq -d | head -n 1)
+  if [[ -n "$duplicated_name" ]]; then
+    >&2 echo "[pggb] ERROR: $input_fasta contains the contig name '$duplicated_name' in more than one sample."
+    >&2 echo "[pggb] Sequence names must be unique; use Pangenome Sequence Naming (sample#haplotype#contig)."
+    exit 1
+  fi
+fi
+
 # Check Pangenome Sequence Naming (PanSN)
 pansn_not_respected=false
 while IFS= read -r line; do
@@ -323,7 +356,7 @@ while IFS= read -r line; do
     pansn_not_respected=$line
     break
   fi
-done < <(cut -f 1 "${input_fasta}.fai")
+done < <(pggb_seq_names)
 if [ "$pansn_not_respected" != "false" ]; then
   >&2 echo "[pggb] warning: there are sequence names (like '$pansn_not_respected') that do not match the Pangenome Sequence Naming (PanSN)."
   
@@ -381,7 +414,7 @@ fi
 
 # Normalization ($n_haps is checked in this part of the script because it is also used for the 'auto' mapping sparsification)
 if [[ $n_haps == false ]]; then
-    n_haps=$(cut -f 1 "${input_fasta}.fai" | cut -f 1,2 -d '#' | sort | uniq | wc -l)
+    n_haps=$(pggb_seq_names | cut -f 1,2 -d '#' | sort | uniq | wc -l)
 fi
 
 sparse_map_cmd=""
@@ -566,7 +599,7 @@ if [[ "$input_paf" == false ]]; then
   if [[ ! -s "$prefix_paf".alignments.$mapper.paf || $resume == false ]]; then
 
     # Count total number of sequences
-    num_sequences=$(wc -l < "${input_fasta}.fai")
+    num_sequences=$(pggb_seq_names | wc -l)
     
     if [[ $num_sequences -lt 50 ]]; then
       # For fewer than 50 sequences, run a single all-vs-all wfmash mapping
@@ -593,7 +626,7 @@ if [[ "$input_paf" == false ]]; then
       echo "[pggb] Running prefix-based mapping for $num_sequences sequences" | tee -a "$log_file"
       
       # Get unique prefixes from the FASTA index
-      prefixes=$(cut -f 1 "${input_fasta}.fai" | cut -f 1 -d '#' | sort -u)
+      prefixes=$(pggb_seq_names | cut -f 1 -d '#' | sort -u)
       
       # Run mapping for each prefix ONLY if its file doesn't exist
       for prefix in $prefixes; do


### PR DESCRIPTION
`-i/--input-fasta` now accepts an AGC (`.agc`) archive in addition to FASTA/FASTQ, in both `pggb` and `partition-before-pggb`.

An `.agc` archive has no samtools `.fai`, so:

- sequence names (for the PanSN check and the haplotype / sequence counts) are enumerated with `agc listctg` instead of `cut -f1 *.fai`;
- `partition-before-pggb` extracts each community with `agc getctg` instead of `samtools faidx` (identical FASTA headers, verified);
- wfmash and seqwish read the archive directly, so nothing is decompressed to a temporary FASTA.

Requires the `agc` binary on `PATH` (checked up front alongside the other tools) and needs the AGC support in wfmash (waveygang/wfmash#400) and seqwish (pangenome/seqwish#144), both merged.

An archive that holds the same contig name in more than one sample is rejected with a clear message: pggb needs unique sequence names, and `agc getctg` writes the bare contig name as the FASTA header, so those records could not be told apart after extraction. PanSN naming (`sample#haplotype#contig`) gives unique names by construction.

Verified on the LPA test data and on 8 yeast genomes (96 Mbp): the `seqwish.gfa` that pggb produces is byte-identical whether the input is the FASTA or the AGC archive built from it (the final `.smooth.final.gfa` is not compared because smoothxg is not deterministic run to run, as two runs on the same FASTA also differ). Runtime and memory are at parity with FASTA input, and the archive is roughly 4x smaller on disk.
